### PR TITLE
feat: Add Jovian hardfork support for XLayer mainnet and testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12690,7 +12690,6 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-op-hardforks",
  "alloy-primitives",
  "eyre",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ alloy-sol-types = { version = "1.4.1", default-features = false }
 alloy-transport-http = { version = "1.1.0" }
 
 # op-alloy
-alloy-op-hardforks = { version = "0.4", default-features = false }
 op-alloy-consensus = { version = "0.22.0", default-features = false }
 op-alloy-network = { version = "0.22.0", default-features = false }
 op-alloy-rpc-jsonrpsee = { version = "0.22.0", default-features = false }

--- a/crates/chainspec/Cargo.toml
+++ b/crates/chainspec/Cargo.toml
@@ -33,7 +33,6 @@ alloy-chains = { workspace = true }
 
 # op
 op-alloy-rpc-types = { workspace = true }
-alloy-op-hardforks = { workspace = true }
 
 # misc
 serde = { workspace = true }

--- a/crates/chainspec/src/xlayer_mainnet.rs
+++ b/crates/chainspec/src/xlayer_mainnet.rs
@@ -284,7 +284,6 @@ mod tests {
     #[test]
     fn test_xlayer_mainnet_jovian_activation() {
         use crate::{XLAYER_MAINNET_HARDFORKS, XLAYER_MAINNET_JOVIAN_TIMESTAMP};
-        use alloy_op_hardforks::OP_MAINNET_JOVIAN_TIMESTAMP;
 
         let spec = &*XLAYER_MAINNET;
         let hardforks = &*XLAYER_MAINNET_HARDFORKS;
@@ -297,8 +296,12 @@ mod tests {
             reth_ethereum_forks::ForkCondition::Timestamp(ts) if ts == XLAYER_MAINNET_JOVIAN_TIMESTAMP
         ));
 
-        // Verify XLayer mainnet uses the same timestamp as OP mainnet
-        assert_eq!(XLAYER_MAINNET_JOVIAN_TIMESTAMP, OP_MAINNET_JOVIAN_TIMESTAMP);
+        // Verify XLayer mainnet uses expected timestamp (same as OP mainnet: 2025-12-02 16:00:01 UTC)
+        const EXPECTED_OP_MAINNET_JOVIAN: u64 = 1764691201;
+        assert_eq!(
+            XLAYER_MAINNET_JOVIAN_TIMESTAMP, EXPECTED_OP_MAINNET_JOVIAN,
+            "XLayer mainnet Jovian timestamp should match OP mainnet"
+        );
 
         // Test activation before Jovian timestamp
         assert!(!spec


### PR DESCRIPTION
## Problem

XLayer network needs to support the Jovian hardfork, but the current code lacks the necessary configuration:
- XLayer mainnet and testnet hardfork configurations do not include Jovian
- Missing Jovian activation timestamp definitions
- Unable to confirm Jovian hardfork loading status when the node starts

## Solution

1. **Add Jovian timestamp constants**
   - Mainnet:  (2025-12-02 16:00:01 UTC)
   - Testnet:  (2025-11-28 11:00:00 UTC)

2. **Update hardfork configurations**
   - Add Jovian hardfork to `XLAYER_MAINNET_HARDFORKS` and `XLAYER_TESTNET_HARDFORKS`
