### PR TITLE
fix: build failed

### DIFF
--- a/DockerfileOp
+++ b/DockerfileOp
@@ -56,7 +56,7 @@ RUN apt-get update && \
 WORKDIR /app
 COPY --from=builder /app/op-reth /usr/local/bin/
 RUN chmod +x /usr/local/bin/op-reth
-COPY LICENSE-* ./
+COPY LICENSE* ./
 
 EXPOSE 30303 30303/udp 9001 8545 8546 7545 8551
 ENTRYPOINT ["/usr/local/bin/op-reth"]


### PR DESCRIPTION
```
Error: building at STEP "COPY LICENSE-* ./": checking on sources under "/data/weixie/xlayer-reth": Rel: can't make  relative to /data/weixie/xlayer-reth; copier: stat: ["/LICENSE-*"]: no such file or directory
```