### PR TITLE
chore(flashblocks): update builder and reth versions, switch builder dep target to main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6739,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "op-rbuilder"
 version = "0.2.13"
-source = "git+https://github.com/okx/op-rbuilder?branch=upstream%2Fdev#44ae013743b90e8a979f84cda3493b14284a6b4c"
+source = "git+https://github.com/okx/op-rbuilder?branch=main#950f0917412a436db6b8ea932427f1ebc5e000cd"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7115,7 +7115,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.2.13"
-source = "git+https://github.com/okx/op-rbuilder?branch=upstream%2Fdev#44ae013743b90e8a979f84cda3493b14284a6b4c"
+source = "git+https://github.com/okx/op-rbuilder?branch=main#950f0917412a436db6b8ea932427f1ebc5e000cd"
 dependencies = [
  "derive_more",
  "eyre",
@@ -8250,7 +8250,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -8296,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8320,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8351,7 +8351,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8371,7 +8371,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8385,7 +8385,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8460,7 +8460,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8470,7 +8470,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8488,7 +8488,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8508,7 +8508,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8518,7 +8518,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8533,7 +8533,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8546,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8558,7 +8558,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8584,7 +8584,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8610,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8668,7 +8668,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8683,7 +8683,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8732,7 +8732,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8756,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8787,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8818,7 +8818,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8842,7 +8842,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8867,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "futures",
  "pin-project",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8939,7 +8939,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8967,7 +8967,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9020,7 +9020,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9031,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9080,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "clap",
  "eyre",
@@ -9104,7 +9104,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9120,7 +9120,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9138,7 +9138,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9151,7 +9151,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9233,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9253,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "serde",
  "serde_json",
@@ -9346,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9374,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "bytes",
  "futures",
@@ -9394,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -9410,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -9419,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "futures",
  "metrics",
@@ -9431,7 +9431,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
 ]
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -9453,7 +9453,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9533,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9555,7 +9555,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9584,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9601,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9625,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9746,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9784,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9808,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9832,7 +9832,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "eyre",
  "http 1.4.0",
@@ -9854,7 +9854,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9866,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-chainspec"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-cli"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9944,7 +9944,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-consensus"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9969,7 +9969,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-evm"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-flashblocks"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-forks"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-node"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10091,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10131,7 +10131,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10151,7 +10151,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-rpc"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-storage"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "reth-optimism-primitives",
@@ -10222,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-txpool"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10279,7 +10279,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10291,7 +10291,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10321,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -10345,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10422,7 +10422,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10449,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10464,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10510,7 +10510,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -10523,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10602,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,7 +10669,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -10696,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10726,7 +10726,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10770,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10831,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10847,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10964,7 +10964,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10987,7 +10987,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11003,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11037,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11047,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "clap",
  "eyre",
@@ -11064,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "clap",
  "eyre",
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11121,7 +11121,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11146,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11173,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11186,7 +11186,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11211,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11230,7 +11230,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11248,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.9.3"
-source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#934ce12407add22239951395e9a2747608017c34"
+source = "git+https://github.com/okx/reth?branch=upstream%2Fdev#46ba19b43826e69e84d3eb5e241758dd4e5fd314"
 dependencies = [
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ revm-inspectors = { version = "0.32.0", default-features = false, features = [
 # ------------------------------------------------------------------------------
 # Flashblocks Dependencies
 # ------------------------------------------------------------------------------
-op-rbuilder = { git = "https://github.com/okx/op-rbuilder", branch = "upstream/dev" }
+op-rbuilder = { git = "https://github.com/okx/op-rbuilder", branch = "main" }
 
 # ------------------------------------------------------------------------------
 # Alloy Dependencies


### PR DESCRIPTION
## Description
chore(flashblocks): update builder and reth versions, switch builder dep target to main branch. Op-rbuilder main branch okx/reth version has been re-targeted to okx/reth's upstream/dev branch - https://github.com/okx/op-rbuilder/pull/48

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): chore

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have reviewed the relevant code guidelines in the `docs/` folder
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

