### PR TITLE
fix(fb): omit extraneous ref

### DIFF
--- a/crates/flashblocks/src/handler.rs
+++ b/crates/flashblocks/src/handler.rs
@@ -84,7 +84,7 @@ where
     }
 
     async fn publish_flashblock(&self, flashblock: &Arc<reth_optimism_flashblocks::FlashBlock>) {
-        match self.ws_pub.publish_op_payload(&flashblock) {
+        match self.ws_pub.publish_op_payload(flashblock) {
             Ok(_) => {
                 debug!(
                     target: "flashblocks",


### PR DESCRIPTION
This when running tests.
<img width="2610" height="588" alt="image" src="https://github.com/user-attachments/assets/49ad01aa-e25c-4dbc-8afe-a6195dc28cfb" />
