### PR TITLE
fix(dockerfile): Set default value to dockerfile

### DIFF
--- a/DockerfileOp
+++ b/DockerfileOp
@@ -39,10 +39,10 @@ ARG FEATURES=""
 ENV FEATURES=$FEATURES
 
 # Git metadata for vergen (used when .git is not available)
-ARG VERGEN_GIT_SHA
+ARG VERGEN_GIT_SHA="00000000" # should be at least 8 chars long
 ENV VERGEN_GIT_SHA=$VERGEN_GIT_SHA
 
-ARG VERGEN_GIT_COMMIT_TIMESTAMP
+ARG VERGEN_GIT_COMMIT_TIMESTAMP=""
 ENV VERGEN_GIT_COMMIT_TIMESTAMP=$VERGEN_GIT_COMMIT_TIMESTAMP
 
 RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml


### PR DESCRIPTION
This pull request makes minor improvements to the `DockerfileOp` by setting default values for build arguments related to Git metadata. These changes help ensure consistent builds even when certain environment variables are not set.

- Docker build configuration:
  * Set a default value of `"00000000"` for the `VERGEN_GIT_SHA` argument to guarantee it is at least 8 characters long.
  * Set a default value of an empty string for the `VERGEN_GIT_COMMIT_TIMESTAMP` argument.

**To fix the error**

if VERGEN_GIT_SHA set to "", these upstream reth code in build.rs will be failed:
``` go 
    let sha = env::var("VERGEN_GIT_SHA")?;
    let sha_short = &sha[0..7];
```

**Error info**
```
147.5    Compiling libp2p-identify v0.47.0
147.6 warning: reth-node-core@1.9.3: VERGEN_GIT_COMMIT_TIMESTAMP overidden
147.6 warning: reth-node-core@1.9.3: VERGEN_GIT_SHA overidden
147.6 error: failed to run custom build command for `reth-node-core v1.9.3 (https://github.com/okx/reth?rev=dff243848a7f7a8c6b74684fd89192ccd55fa03e#dff24384)`
147.6
147.6 Caused by:
147.6   process didn't exit successfully: `/app/target/release/build/reth-node-core-90ca48e7799c070b/build-script-build` (exit status: 101)
147.6   --- stdout
147.6   cargo:rustc-env=VERGEN_BUILD_TIMESTAMP=2025-12-22T07:33:25.544073886Z
147.6   cargo:rustc-env=VERGEN_CARGO_FEATURES=jemalloc,otlp
147.6   cargo:rustc-env=VERGEN_CARGO_TARGET_TRIPLE=aarch64-unknown-linux-gnu
147.6   cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=
147.6   cargo:rustc-env=VERGEN_GIT_DESCRIBE=dff2438
147.6   cargo:rustc-env=VERGEN_GIT_SHA=
147.6   cargo:rustc-env=VERGEN_GIT_DIRTY=true
147.6   cargo:warning=VERGEN_GIT_COMMIT_TIMESTAMP overidden
147.6   cargo:warning=VERGEN_GIT_SHA overidden
147.6   cargo:rerun-if-changed=/usr/local/cargo/git/checkouts/reth-3921489b8028fb0e/dff2438/.git/HEAD
147.6   cargo:rerun-if-changed=/usr/local/cargo/git/checkouts/reth-3921489b8028fb0e/dff2438/.git/refs/heads/master
147.6   cargo:rerun-if-changed=build.rs
147.6   cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
147.6   cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
147.6
147.6   --- stderr
147.6
147.6   thread 'main' panicked at /usr/local/cargo/git/checkouts/reth-3921489b8028fb0e/dff2438/crates/node/core/build.rs:25:25:
147.6   byte index 7 is out of bounds of ``
147.6   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
147.6 warning: build failed, waiting for other jobs to finish...
163.5
163.5 thread 'main' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-chef-0.1.73/src/recipe.rs:218:27:
163.5 Exited with status code: 101
163.5 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
------
DockerfileOp:48
--------------------
  46 |     ENV VERGEN_GIT_COMMIT_TIMESTAMP=$VERGEN_GIT_COMMIT_TIMESTAMP
  47 |
  48 | >>> RUN cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml
  49 |
  50 |     COPY . .
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c cargo chef cook --profile $BUILD_PROFILE --features \"$FEATURES\" --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml" did not complete successfully: exit code: 101

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/rxv7locjplb55d236xtbes2fh
error: Recipe `build-docker` failed with exit code 1
```