### PR TITLE
1/2 version crate compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14136,7 +14136,6 @@ dependencies = [
 name = "xlayer-version"
 version = "0.1.0"
 dependencies = [
- "reth",
  "reth-node-core",
  "vergen",
  "vergen-git2",

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -8,9 +8,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-reth.workspace = true
-
-[dev-dependencies]
 reth-node-core.workspace = true
 
 [build-dependencies]

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 reth-node-core.workspace = true
 
 [build-dependencies]
-vergen = "=9.0.6"
+vergen = { version = "=9.0.6", features = ["cargo", "emit_and_set"] }
 vergen-git2 = "1.0.7"
 
 [lints]

--- a/crates/version/src/lib.rs
+++ b/crates/version/src/lib.rs
@@ -1,7 +1,9 @@
+extern crate alloc;
+
 use reth::version::{
     default_reth_version_metadata, try_init_version_metadata, RethCliVersionConsts,
 };
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 const XLAYER_RETH_CLIENT_VERSION: &str = concat!("xlayer/v", env!("CARGO_PKG_VERSION"));
 

--- a/crates/version/src/lib.rs
+++ b/crates/version/src/lib.rs
@@ -1,9 +1,11 @@
+#![no_std]
+
 extern crate alloc;
 
-use reth::version::{
+use reth_node_core::version::{
     default_reth_version_metadata, try_init_version_metadata, RethCliVersionConsts,
 };
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, format};
 
 const XLAYER_RETH_CLIENT_VERSION: &str = concat!("xlayer/v", env!("CARGO_PKG_VERSION"));
 


### PR DESCRIPTION
Improve build time of this crate by shrinking core dependency and disabling std lib.

### Before
<img width="412" height="380" alt="Targets xlayer-version 0 1 0 (lib)" src="https://github.com/user-attachments/assets/39b50411-1c0a-4951-ab9b-ef8287c71fee" />

### After
<img width="412" height="380" alt="Targets" src="https://github.com/user-attachments/assets/f2443019-5dd0-49d5-83c4-fc1beae6e678" />
