### PR TITLE
chore(flashblocks): fix flashblocks rpc service logging level on init

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use args_xlayer::XLayerArgs;
 use clap::Parser;
-use tracing::{error, info, warn};
+use tracing::{error, info, trace};
 
 use op_rbuilder::{
     args::OpRbuilderArgs,
@@ -194,7 +194,7 @@ fn main() {
                             service.spawn();
                             info!(target: "reth::cli", "xlayer flashblocks service initialized");
                         } else {
-                            warn!(target: "reth::cli", "unable to get flashblock receiver, xlayer flashblocks service not initialized");
+                            trace!(target: "reth::cli", "unable to get flashblock receiver, xlayer flashblocks service not initialized");
                         }
 
                         if let Some(pending_blocks_rx) = new_op_eth_api.pending_block_rx() {
@@ -212,7 +212,7 @@ fn main() {
                             )?;
                             info!(target: "reth::cli", "xlayer eth pubsub initialized");
                         } else {
-                            warn!(target: "reth::cli", "unable to get pending blocks receiver, flashblocks eth pubsub not replaced");
+                            trace!(target: "reth::cli", "unable to get pending blocks receiver, flashblocks pubsub not initialized");
                         }
 
                         // Register XLayer RPC


### PR DESCRIPTION
## Summary

- Fix incorrect logging level. The PR fixes the warning logs when flashblocks RPC is disabled (`--flashblocks-url` is unset), flashblocks service should fail to init when it is the intended behaviour to disable flashblocks RPC