### PR TITLE
chore(flashblocks): Add flashblocks eth subscription enable flag

### DIFF
--- a/bin/node/src/args_xlayer.rs
+++ b/bin/node/src/args_xlayer.rs
@@ -17,6 +17,14 @@ pub struct XLayerArgs {
         default_value = "false"
     )]
     pub enable_inner_tx: bool,
+
+    /// Enable custom flashblocks subscription
+    #[arg(
+        long = "xlayer.flashblocks-subscription",
+        help = "Enable custom flashblocks subscription (disabled by default)",
+        default_value = "false"
+    )]
+    pub enable_flashblocks_subscription: bool,
 }
 
 impl XLayerArgs {
@@ -249,10 +257,12 @@ mod tests {
             "--rpc.legacy-timeout",
             "45s",
             "--xlayer.enable-innertx",
+            "--xlayer.flashblocks-subscription",
         ])
         .args;
 
         assert!(args.enable_inner_tx);
+        assert!(args.enable_flashblocks_subscription);
         assert!(args.legacy.legacy_rpc_url.is_some());
         assert_eq!(args.legacy.legacy_rpc_timeout, Duration::from_secs(45));
         assert!(args.validate().is_ok());
@@ -266,6 +276,7 @@ mod tests {
                 legacy_rpc_timeout: Duration::from_secs(30),
             },
             enable_inner_tx: false,
+            enable_flashblocks_subscription: false,
         };
 
         let result = args.validate();

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
                             info!(target: "reth::cli", "xlayer innertx rpc enabled");
                         }
 
-                        if let Some(flashblock_rx) = new_op_eth_api.subscribe_received_flashblocks() {
+                        if args.xlayer_args.enable_flashblocks_subscription && let Some(flashblock_rx) = new_op_eth_api.subscribe_received_flashblocks() {
                             let service = FlashblocksService::new(
                                 ctx.node().clone(),
                                 flashblock_rx,


### PR DESCRIPTION
## Summary

- Adds the configuration flag `--xlayer.flashblocks-subscription` to enable custom flashblock subscription mode in eth_subscribe api.