### PR TITLE
fix: specify eviction policy for cache

### DIFF
--- a/crates/flashblocks/src/subscription.rs
+++ b/crates/flashblocks/src/subscription.rs
@@ -24,11 +24,10 @@ use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err};
 use reth_storage_api::BlockNumReader;
 use reth_tasks::TaskSpawner;
 use reth_tracing::tracing::warn;
-use std::{future::ready, sync::Arc, time::Duration};
+use std::{future::ready, sync::Arc};
 use tokio_stream::{wrappers::WatchStream, Stream};
 
 const MAX_TXHASH_CACHE_SIZE: u64 = 10_000;
-const TXHASH_CACHE_TTL: Duration = Duration::from_secs(5);
 
 type FlashblockItem<N, C> = FlashblockStreamEvent<
     <N as NodePrimitives>::BlockHeader,
@@ -192,7 +191,6 @@ where
         let txhash_cache = Cache::builder()
             .max_capacity(MAX_TXHASH_CACHE_SIZE)
             .eviction_policy(EvictionPolicy::lru())
-            .time_to_live(TXHASH_CACHE_TTL)
             .build();
 
         WatchStream::new(self.pending_block_rx.clone())


### PR DESCRIPTION
## Description
We need to change the eviction policy to LRU. The default eviction policy for moka cache is the TinyLFU policy, which will admit a new entry based on its popularity. If the key of the entry is popular, it will be admitted to the cache. Otherwise, it will be rejected. This rejection caused the deduplication logic to fail after the cache reaches its max capacity, leading to duplicated messages sent downstream.


## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Code Guidelines
Before submitting your PR, please review the relevant code guidelines in the `docs/` folder:

- **[Building on Reth Guide](../docs/BUILDING_ON_RETH.md)** - Comprehensive guide for building on top of Reth

### Specific Guidelines by Component:
- **[Chainspec & EVM Guide](../docs/subguides/CHAINSPEC_EVM_GUIDE.md)** - For changes to chainspec or EVM configuration
- **[Database Guide](../docs/subguides/DATABASE_GUIDE.md)** - For changes to database tables or storage
- **[Engine & Consensus Guide](../docs/subguides/ENGINE_CONSENSUS_GUIDE.md)** - For changes to consensus or engine API
- **[Extension Guide](../docs/subguides/EXTENSION_GUIDE.md)** - For adding extensions or plugins
- **[Node Builder Guide](../docs/subguides/NODE_BUILDER_GUIDE.md)** - For changes to node initialization
- **[Payload Builder Guide](../docs/subguides/PAYLOAD_BUILDER_GUIDE.md)** - For changes to block building logic

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have reviewed the relevant code guidelines in the `docs/` folder
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing
`just test`