### PR TITLE
fix(flashblocks): switch subscribed address filter to hashset, add max sub address check

### DIFF
--- a/bin/node/src/args_xlayer.rs
+++ b/bin/node/src/args_xlayer.rs
@@ -17,6 +17,14 @@ pub struct XLayerArgs {
         default_value = "false"
     )]
     pub enable_flashblocks_subscription: bool,
+
+    /// Set the number of subscribed addresses in flashblocks subscription
+    #[arg(
+        long = "xlayer.flashblocks-subscription-max-addresses",
+        help = "Set the number of subscribed addresses in flashblocks subscription",
+        default_value = "1000"
+    )]
+    pub flashblocks_subscription_max_addresses: usize,
 }
 
 impl XLayerArgs {
@@ -249,12 +257,15 @@ mod tests {
             "--rpc.legacy-timeout",
             "45s",
             "--xlayer.flashblocks-subscription",
+            "--xlayer.flashblocks-subscription-max-addresses",
+            "2000",
         ])
         .args;
 
         assert!(args.enable_flashblocks_subscription);
         assert!(args.legacy.legacy_rpc_url.is_some());
         assert_eq!(args.legacy.legacy_rpc_timeout, Duration::from_secs(45));
+        assert_eq!(args.flashblocks_subscription_max_addresses, 2000);
         assert!(args.validate().is_ok());
     }
 
@@ -266,6 +277,7 @@ mod tests {
                 legacy_rpc_timeout: Duration::from_secs(30),
             },
             enable_flashblocks_subscription: false,
+            flashblocks_subscription_max_addresses: 1000,
         };
 
         let result = args.validate();

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -163,6 +163,7 @@ fn main() {
                                 pending_blocks_rx,
                                 Box::new(ctx.node().task_executor().clone()),
                                 new_op_eth_api.tx_resp_builder().clone(),
+                                args.xlayer_args.flashblocks_subscription_max_addresses,
                             );
                             ctx.modules.add_or_replace_if_module_configured(
                                 RethRpcModule::Eth,

--- a/crates/flashblocks/src/pubsub.rs
+++ b/crates/flashblocks/src/pubsub.rs
@@ -10,9 +10,6 @@ use std::collections::HashSet;
 
 const FLASHBLOCKS: &str = "flashblocks";
 
-/// Maximum number of addresses that can be subscribed to.
-const MAX_SUBSCRIBED_ADDRESSES: usize = 1_000;
-
 /// Subscription kind inclusive of flashblocks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
@@ -60,9 +57,9 @@ pub enum FlashblockParams {
 
 impl FlashblockParams {
     /// Validates the flashblock params.
-    pub fn validate(&self) -> Result<(), ErrorObject<'static>> {
+    pub fn validate(&self, max_subscribed_addresses: usize) -> Result<(), ErrorObject<'static>> {
         if let FlashblockParams::FlashblocksFilter(filter) = self {
-            if filter.sub_tx_filter.subscribe_addresses.len() > MAX_SUBSCRIBED_ADDRESSES {
+            if filter.sub_tx_filter.subscribe_addresses.len() > max_subscribed_addresses {
                 return Err(invalid_params_rpc_err("too many subscribe addresses"));
             }
         }


### PR DESCRIPTION
## Summary

- Resolve eth_subscribe flashblocks interface where  tx filter's subscribed addresses is incorrectly stored in a vector. This PR switches to use a hashset instead
- Add additional validation check on the flashblock filter parameters specified by the user. We limit the number of subscribed addresses the user can specify to a configurable limit (`xlayer.flashblocks-subscription-max-addresses`), default at 1_000