### PR TITLE
chore: refactor e2e for flashblocks RPC

### DIFF
--- a/crates/tests/operations/manager.rs
+++ b/crates/tests/operations/manager.rs
@@ -24,7 +24,7 @@ pub const DEFAULT_L2_NETWORK_URL_NO_FB: &str = "http://localhost:8128";
 /// Default Flashblocks WebSocket URL for testing
 pub const DEFAULT_SEQ_FLASHBLOCKS_WS_URL: &str = "ws://localhost:11111";
 /// Default Flashblocks WebSocket URL for testing
-pub const DEFAULT_FLASHBLOCKS_WS_URL: &str = "ws://localhost:11112";
+pub const DEFAULT_SEQ_2_FLASHBLOCKS_WS_URL: &str = "ws://localhost:11112";
 /// Default Flashblocks WebSocket URL for RPC node which obtains flashblocks from the sequencer
 pub const DEFAULT_RPC_FLASHBLOCKS_WS_URL: &str = "ws://localhost:11113";
 /// Default WebSocket URL for testing


### PR DESCRIPTION
## Description
Add E2E test to ensure that RPC can relay flashblocks raw data

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Update tests

## Code Guidelines
Before submitting your PR, please review the relevant code guidelines in the `docs/` folder:

- **[Building on Reth Guide](../docs/BUILDING_ON_RETH.md)** - Comprehensive guide for building on top of Reth

### Specific Guidelines by Component:
- **[Chainspec & EVM Guide](../docs/subguides/CHAINSPEC_EVM_GUIDE.md)** - For changes to chainspec or EVM configuration
- **[Database Guide](../docs/subguides/DATABASE_GUIDE.md)** - For changes to database tables or storage
- **[Engine & Consensus Guide](../docs/subguides/ENGINE_CONSENSUS_GUIDE.md)** - For changes to consensus or engine API
- **[Extension Guide](../docs/subguides/EXTENSION_GUIDE.md)** - For adding extensions or plugins
- **[Node Builder Guide](../docs/subguides/NODE_BUILDER_GUIDE.md)** - For changes to node initialization
- **[Payload Builder Guide](../docs/subguides/PAYLOAD_BUILDER_GUIDE.md)** - For changes to block building logic

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have reviewed the relevant code guidelines in the `docs/` folder
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing
`cargo test -p xlayer-e2e-test --test flashblocks_tests -- fb_subscription_test_rpc --include-ignored --nocapture --test-threads=1`

