### PR TITLE
fix(rpc): remove incorrect block_number subtraction in pre_exec logs

### DIFF
--- a/crates/rpc/src/pre_exec_ext_xlayer.rs
+++ b/crates/rpc/src/pre_exec_ext_xlayer.rs
@@ -409,11 +409,7 @@ pub trait PreExec: EthCall {
                 .map(|(idx, log)| alloy_rpc_types_eth::Log {
                     inner: log.clone(),
                     block_hash,
-                    block_number: Some(
-                        block_number
-                            .saturating_sub(alloy_primitives::U256::from(1))
-                            .saturating_to(),
-                    ),
+                    block_number: Some(block_number.saturating_to()),
                     transaction_hash: Some(tx_hash),
                     transaction_index: Some(tx_index),
                     log_index: Some(idx as u64),


### PR DESCRIPTION
### Problem

In `transaction_pre_exec` RPC, the `block_number` field in returned logs was incorrectly subtracting 1 from the actual block number:

```
block_number: Some(
    block_number
        .saturating_sub(alloy_primitives::U256::from(1))
        .saturating_to(),
),
```

This caused inconsistency with Erigon's implementation, where logs use the actual block number without subtraction.

### Changes
Remove the .saturating_sub(alloy_primitives::U256::from(1)) operation, keeping the log's block_number consistent with:
The PreExecResult.block_number field in the same response
