### PR TITLE
feat: upgrade to upstream reth v1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e30ab0d3e3c32976f67fc1a96179989e45a69594af42003a6663332f9b0bb9d"
+checksum = "5c3a590d13de3944675987394715f37537b50b856e3b23a0e66e97d963edbf38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20736b1f9d927d875d8777ef0c2250d4c57ea828529a9dbfa2c628db57b911e"
+checksum = "0f28f769d5ea999f0d8a105e434f483456a15b4e1fcb08edbbbe1650a497ff6d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008aba161fce2a0d94956ae09d7d7a09f8fbdf18acbef921809ef126d6cdaf97"
+checksum = "990fa65cd132a99d3c3795a82b9f93ec82b81c7de3bab0bf26ca5c73286f7186"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -237,10 +237,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.4.0"
+name = "alloy-eip7928"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b85157b7be31fc4adf6acfefcb0d4308cba5dbd7a8d8e62bcc02ff37d6131a"
+checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09535cbc646b0e0c6fcc12b7597eaed12cf86dff4c4fba9507a61e71b94f30eb"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -264,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.23.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b47dc39850c6168002ddc1f7a2063e15d26137c1bb5330f6065a7524c1aa9"
+checksum = "e6ccc4c702c840148af1ce784cc5c6ed9274a020ef32417c5b1dbeab8c317673"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -278,8 +289,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus",
- "op-alloy-rpc-types-engine",
+ "op-alloy",
  "op-revm",
  "revm",
  "thiserror 2.0.17",
@@ -287,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a838301c4e2546c96db1848f18ffe9f722f2fccd9715b83d4bf269a2cf00b5a1"
+checksum = "1005520ccf89fa3d755e46c1d992a9e795466c2e7921be2145ef1f749c5727de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -328,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f045b69b5e80b8944b25afe74ae6b974f3044d84b4a7a113da04745b2524cc"
+checksum = "72b626409c98ba43aaaa558361bca21440c88fd30df7542c7484b9c7a1489cdb"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -343,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b314ed5bdc7f449c53853125af2db5ac4d3954a9f4b205e7d694f02fc1932d1"
+checksum = "89924fdcfeee0e0fa42b1f10af42f92802b5d16be614a70897382565663bf7cf"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -369,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9762ac5cca67b0f6ab614f7f8314942eead1c8eeef61511ea43a6ff048dbe0"
+checksum = "0f0dbe56ff50065713ff8635d8712a0895db3ad7f209db9793ad8fcb6b1734aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -382,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.23.3"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea81517a852d9e3b03979c10febe00aacc3d50fbd34c5c30281051773285f7"
+checksum = "0f640da852f93ddaa3b9a602b7ca41d80e0023f77a67b68aaaf511c32f1fe0ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -392,7 +402,7 @@ dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
- "op-alloy-consensus",
+ "op-alloy",
  "op-revm",
  "revm",
  "thiserror 2.0.17",
@@ -422,6 +432,7 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more",
+ "fixed-cache",
  "foldhash 0.2.0",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
@@ -443,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8f7ca47514e7f552aa9f3f141ab17351332c6637e3bf00462d8e7c5f10f51f"
+checksum = "8b56f7a77513308a21a2ba0e9d57785a9d9d2d609e77f4e71a78a1192b83ff2d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -456,8 +467,10 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
@@ -487,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4082778c908aa801a1f9fdc85d758812842ab4b2aaba58e9dbe7626d708ab7e1"
+checksum = "94813abbd7baa30c700ea02e7f92319dbcb03bff77aeea92a3a9af7ba19c5c70"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -531,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dd083153d2cb73cce1516f5a3f9c3af74764a2761d901581a355777468bd8f"
+checksum = "ff01723afc25ec4c5b04de399155bef7b6a96dfde2475492b1b7b4e7a4f46445"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -557,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c998214325cfee1fbe61e5abaed3a435f4ca746ac7399b46feb57c364552452"
+checksum = "f91bf006bb06b7d812591b6ac33395cb92f46c6a65cda11ee30b348338214f0f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -570,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730a38742dc0753f25b8ce7330c2fa88d79f165c5fc2f19f3d35291739c42e83"
+checksum = "b934c3bcdc6617563b45deb36a40881c8230b94d0546ea739dff7edb3aa2f6fd"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -582,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b03d65fcf579fbf17d3aac32271f99e2b562be04097436cd6e766b3e06613b"
+checksum = "7e82145856df8abb1fefabef58cdec0f7d9abf337d4abd50c1ed7e581634acdd"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -594,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4a6f49d161ef83354d5ba3c8bc83c8ee464cb90182b215551d5c4b846579be"
+checksum = "212ca1c1dab27f531d3858f8b1a2d6bfb2da664be0c1083971078eb7b71abe4b"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -605,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6654644613f33fd2e6f333f4ce8ad0a26f036c0513699d7bc168bba18d412d"
+checksum = "6d92a9b4b268fac505ef7fb1dac9bb129d4fd7de7753f22a5b6e9f666f7f7de6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -625,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467025b916f32645f322a085d0017f2996d0200ac89dd82a4fc2bf0f17b9afa3"
+checksum = "bab1ebed118b701c497e6541d2d11dfa6f3c6ae31a3c52999daa802fcdcc16b7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -637,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933aaaace9faa6d7efda89472add89a8bfd15270318c47a2be8bb76192c951e2"
+checksum = "232f00fcbcd3ee3b9399b96223a8fc884d17742a70a44f9d7cef275f93e6e872"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -657,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11920b16ab7c86052f990dcb4d25312fb2889faf506c4ee13dc946b450536989"
+checksum = "5715d0bf7efbd360873518bd9f6595762136b5327a9b759a8c42ccd9b5e44945"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -679,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1826454c2890af6d642bf052909e0162ad7f261d172e56ef2e936d479960699c"
+checksum = "c7b61941d2add2ee64646612d3eda92cbbde8e6c933489760b6222c8898c79be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -694,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498375e6a13b6edd04422a13d2b1a6187183e5a3aa14c5907b4c566551248bab"
+checksum = "9763cc931a28682bd4b9a68af90057b0fbe80e2538a82251afd69d7ae00bbebf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -708,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9123d321ecd70925646eb2c60b1d9b7a965f860fbd717643e2c20fcf85d48d"
+checksum = "359a8caaa98cb49eed62d03f5bc511dd6dd5dee292238e8627a6e5690156df0f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -720,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a0d2d5c64881f3723232eaaf6c2d9f4f88b061c63e87194b2db785ff3aa31f"
+checksum = "5ed8531cae8d21ee1c6571d0995f8c9f0652a6ef6452fde369283edea6ab7138"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -732,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea4ac9765e5a7582877ca53688e041fe184880fe75f16edf0945b24a319c710"
+checksum = "fb10ccd49d0248df51063fce6b716f68a315dd912d55b32178c883fd48b4021d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -747,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9d85b9f7105ab5ce7dae7b0da33cd9d977601a48f759e1c82958978dd1a905"
+checksum = "f4d992d44e6c414ece580294abbadb50e74cfd4eaa69787350a4dfd4b20eaa1b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -839,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e72f5c4ba505ebead6a71144d72f21a70beadfb2d84e0a560a985491ecb71de"
+checksum = "3f50a9516736d22dd834cc2240e5bf264f338667cc1d9e514b55ec5a78b987ca"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -862,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400dc298aaabdbd48be05448c4a19eaa38416c446043f3e54561249149269c32"
+checksum = "0a18b541a6197cf9a084481498a766fdf32fefda0c35ea6096df7d511025e9f1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -880,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba22ff961cf99495ee4fdbaf4623f8d5483d408ca2c6e1b1a54ef438ca87f8dd"
+checksum = "8075911680ebc537578cacf9453464fd394822a0f68614884a9c63f9fbaf5e89"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -900,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38b4472f2bbd96a27f393de9e2f12adca0dc1075fb4d0f7c8f3557c5c600392"
+checksum = "921d37a57e2975e5215f7dd0f28873ed5407c7af630d4831a4b5c737de4b0b8b"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -937,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2183706e24173309b0ab0e34d3e53cf3163b71a419803b2b3b0c1fb7ff7a941"
+checksum = "b2289a842d02fe63f8c466db964168bb2c7a9fdfb7b24816dbb17d45520575fb"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -3528,6 +3541,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-cache"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25d3af83468398d500e9bc19e001812dcb1a11e4d3d6a5956c789aa3c11a8cb5"
+dependencies = [
+ "equivalent",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3537,6 +3559,27 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "fixed-map"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ed19add84e8cb9e8cc5f7074de0324247149ffef0b851e215fb0edc50c229b"
+dependencies = [
+ "fixed-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "fixed-map-derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5658,16 +5701,16 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5688,13 +5731,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "metrics",
  "quanta",
  "rand 0.9.2",
@@ -6203,10 +6246,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
+name = "op-alloy"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
+checksum = "e9b8fee21003dd4f076563de9b9d26f8c97840157ef78593cd7f262c5ca99848"
+dependencies = [
+ "op-alloy-consensus",
+ "op-alloy-network",
+ "op-alloy-provider",
+ "op-alloy-rpc-types",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736381a95471d23e267263cfcee9e1d96d30b9754a94a2819148f83379de8a86"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6230,9 +6286,9 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.22.4"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63f27e65be273ec8fcb0b6af0fd850b550979465ab93423705ceb3dfddbd2ab"
+checksum = "4034183dca6bff6632e7c24c92e75ff5f0eabb58144edb4d8241814851334d47"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -6245,10 +6301,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-rpc-jsonrpsee"
-version = "0.22.4"
+name = "op-alloy-provider"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef9114426b16172254555aad34a8ea96c01895e40da92f5d12ea680a1baeaa7"
+checksum = "6753d90efbaa8ea8bcb89c1737408ca85fa60d7adb875049d3f382c063666f86"
+dependencies = [
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-engine",
+ "alloy-transport",
+ "async-trait",
+ "op-alloy-rpc-types-engine",
+]
+
+[[package]]
+name = "op-alloy-rpc-jsonrpsee"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c820ef9c802ebc732281a940bfb6ac2345af4d9fff041cbb64b4b546676686"
 dependencies = [
  "alloy-primitives",
  "jsonrpsee",
@@ -6256,9 +6327,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.22.4"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562dd4462562c41f9fdc4d860858c40e14a25df7f983ae82047f15f08fce4d19"
+checksum = "ddd87c6b9e5b6eee8d6b76f41b04368dca0e9f38d83338e5b00e730c282098a4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6275,9 +6346,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.22.4"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f24b8cb66e4b33e6c9e508bf46b8ecafc92eadd0b93fedd306c0accb477657"
+checksum = "77727699310a18cdeed32da3928c709e2704043b6584ed416397d5da65694efc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6290,14 +6361,15 @@ dependencies = [
  "ethereum_ssz_derive",
  "op-alloy-consensus",
  "serde",
+ "sha2",
  "snap",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "op-rbuilder"
-version = "0.2.13"
-source = "git+https://github.com/okx/op-rbuilder?tag=v0.2.1#e1fdbf3cdbfb43bf871782ef1715b7da550375f4"
+version = "0.2.14"
+source = "git+https://github.com/okx/op-rbuilder?tag=v0.2.3#375c26f04047a8adad4e38e868a10929af63caa4"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -6417,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31622d03b29c826e48800f4c8f389c8a9c440eb796a3e35203561a288f12985"
+checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6494,6 +6566,18 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.17",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
 ]
 
 [[package]]
@@ -6582,8 +6666,8 @@ dependencies = [
 
 [[package]]
 name = "p2p"
-version = "0.2.13"
-source = "git+https://github.com/okx/op-rbuilder?tag=v0.2.1#e1fdbf3cdbfb43bf871782ef1715b7da550375f4"
+version = "0.2.14"
+source = "git+https://github.com/okx/op-rbuilder?tag=v0.2.3#375c26f04047a8adad4e38e868a10929af63caa4"
 dependencies = [
  "derive_more",
  "eyre",
@@ -7587,8 +7671,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7633,8 +7717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7657,8 +7741,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7688,8 +7772,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7708,8 +7792,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7722,8 +7806,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7741,6 +7825,7 @@ dependencies = [
  "humantime",
  "itertools 0.14.0",
  "lz4",
+ "metrics",
  "ratatui",
  "reqwest",
  "reth-chainspec",
@@ -7781,6 +7866,7 @@ dependencies = [
  "reth-stages",
  "reth-static-file",
  "reth-static-file-types",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
@@ -7792,13 +7878,14 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tracing",
+ "url",
  "zstd",
 ]
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7807,8 +7894,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7825,8 +7912,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7845,8 +7932,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7855,14 +7942,15 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "eyre",
  "humantime-serde",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
+ "reth-static-file-types",
  "serde",
  "toml",
  "url",
@@ -7870,8 +7958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7883,8 +7971,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7895,8 +7983,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7921,8 +8009,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7947,8 +8035,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7975,8 +8063,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8005,8 +8093,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8020,8 +8108,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8045,8 +8133,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8069,8 +8157,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8093,8 +8181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8124,8 +8212,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8137,26 +8225,23 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "generic-array",
  "hmac",
  "pin-project",
  "rand 0.8.5",
  "reth-network-peers",
  "secp256k1 0.30.0",
  "sha2",
- "sha3",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
- "typenum",
 ]
 
 [[package]]
 name = "reth-engine-local"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8170,6 +8255,7 @@ dependencies = [
  "reth-optimism-chainspec",
  "reth-payload-builder",
  "reth-payload-primitives",
+ "reth-primitives-traits",
  "reth-storage-api",
  "reth-transaction-pool",
  "tokio",
@@ -8179,8 +8265,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8204,8 +8290,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "futures",
  "pin-project",
@@ -8226,10 +8312,11 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -8241,6 +8328,7 @@ dependencies = [
  "futures",
  "metrics",
  "mini-moka",
+ "moka",
  "parking_lot",
  "rayon",
  "reth-chain-state",
@@ -8276,8 +8364,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8304,8 +8392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8313,21 +8401,21 @@ dependencies = [
  "alloy-rlp",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "reth-ethereum-primitives",
  "snap",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "eyre",
  "futures-util",
  "reqwest",
+ "reth-era",
  "reth-fs-util",
  "sha2",
  "tokio",
@@ -8335,8 +8423,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8357,8 +8445,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8368,8 +8456,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8396,8 +8484,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8417,8 +8505,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "clap",
  "eyre",
@@ -8434,15 +8522,13 @@ dependencies = [
  "reth-node-metrics",
  "reth-rpc-server-types",
  "reth-tracing",
- "reth-tracing-otlp",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8457,8 +8543,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8475,8 +8561,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8488,8 +8574,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8517,8 +8603,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8537,8 +8623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8547,8 +8633,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8558,6 +8644,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "metrics",
+ "rayon",
  "reth-execution-errors",
  "reth-execution-types",
  "reth-metrics",
@@ -8570,14 +8657,15 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "derive_more",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -8590,8 +8678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8603,8 +8691,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8621,8 +8709,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8659,8 +8747,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8673,8 +8761,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "serde",
  "serde_json",
@@ -8683,8 +8771,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8711,8 +8799,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "bytes",
  "futures",
@@ -8731,8 +8819,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8747,8 +8835,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8756,8 +8844,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "futures",
  "metrics",
@@ -8768,16 +8856,17 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
+ "ipnet",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -8790,8 +8879,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8809,6 +8898,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "rand 0.9.2",
+ "rayon",
  "reth-chainspec",
  "reth-consensus",
  "reth-discv4",
@@ -8845,8 +8935,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8870,8 +8960,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8892,8 +8982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8907,8 +8997,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8921,8 +9011,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8938,8 +9028,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8962,8 +9052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8976,11 +9066,11 @@ dependencies = [
  "fdlimit",
  "futures",
  "jsonrpsee",
+ "parking_lot",
  "rayon",
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
- "reth-cli-util",
  "reth-config",
  "reth-consensus",
  "reth-consensus-debug-client",
@@ -9030,8 +9120,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9043,6 +9133,7 @@ dependencies = [
  "eyre",
  "futures",
  "humantime",
+ "ipnet",
  "rand 0.9.2",
  "reth-chainspec",
  "reth-cli-util",
@@ -9054,11 +9145,13 @@ dependencies = [
  "reth-engine-local",
  "reth-engine-primitives",
  "reth-ethereum-forks",
+ "reth-net-banlist",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",
  "reth-network-peers",
  "reth-primitives-traits",
+ "reth-provider",
  "reth-prune-types",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
@@ -9083,8 +9176,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9121,8 +9214,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9145,8 +9238,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9169,11 +9262,13 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
+ "bytes",
  "eyre",
  "http",
+ "http-body-util",
  "jsonrpsee-server",
  "metrics",
  "metrics-exporter-prometheus",
@@ -9191,8 +9286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9203,8 +9298,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9231,8 +9326,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9271,18 +9366,16 @@ dependencies = [
  "reth-static-file",
  "reth-static-file-types",
  "reth-tracing",
- "reth-tracing-otlp",
  "serde",
  "tokio",
  "tokio-util",
  "tracing",
- "url",
 ]
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9306,8 +9399,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9334,8 +9427,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9371,8 +9464,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9382,8 +9475,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9428,8 +9521,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9439,10 +9532,10 @@ dependencies = [
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "derive_more",
+ "either",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "reth-basic-payload-builder",
- "reth-chain-state",
  "reth-chainspec",
  "reth-evm",
  "reth-execution-types",
@@ -9468,28 +9561,23 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "arbitrary",
- "bytes",
- "modular-bitfield",
  "op-alloy-consensus",
- "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9549,8 +9637,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "reth-optimism-primitives",
@@ -9559,8 +9647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9595,8 +9683,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9616,8 +9704,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9628,9 +9716,10 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
+ "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9640,7 +9729,9 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-errors",
+ "reth-execution-types",
  "reth-primitives-traits",
+ "reth-trie-common",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -9648,8 +9739,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9658,8 +9749,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9668,8 +9759,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9682,8 +9773,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9715,8 +9806,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9738,7 +9829,6 @@ dependencies = [
  "reth-ethereum-engine-primitives",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-fs-util",
  "reth-metrics",
  "reth-nippy-jar",
  "reth-node-types",
@@ -9759,8 +9849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9776,6 +9866,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-provider",
  "reth-prune-types",
+ "reth-stages-types",
  "reth-static-file-types",
  "reth-tokio-util",
  "rustc-hash",
@@ -9786,8 +9877,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9801,8 +9892,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9820,8 +9911,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9847,8 +9938,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9860,11 +9951,12 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
@@ -9903,6 +9995,8 @@ dependencies = [
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-errors",
+ "reth-ethereum-engine-primitives",
+ "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -9939,9 +10033,10 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-genesis",
  "alloy-json-rpc",
@@ -9963,12 +10058,14 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9980,6 +10077,7 @@ dependencies = [
  "reth-chain-state",
  "reth-chainspec",
  "reth-consensus",
+ "reth-engine-primitives",
  "reth-evm",
  "reth-ipc",
  "reth-metrics",
@@ -9994,6 +10092,7 @@ dependencies = [
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
+ "reth-tokio-util",
  "reth-transaction-pool",
  "serde",
  "thiserror 2.0.17",
@@ -10006,10 +10105,11 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -10021,20 +10121,18 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
- "op-revm",
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-optimism-primitives",
  "reth-primitives-traits",
  "reth-storage-api",
- "revm-context",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10043,10 +10141,10 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "metrics",
- "parking_lot",
  "reth-chainspec",
  "reth-engine-primitives",
  "reth-metrics",
+ "reth-network-api",
  "reth-payload-builder",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
@@ -10063,8 +10161,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10107,8 +10205,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10150,12 +10248,13 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10168,8 +10267,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10184,8 +10283,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10218,6 +10317,7 @@ dependencies = [
  "reth-revm",
  "reth-stages-api",
  "reth-static-file-types",
+ "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
@@ -10228,8 +10328,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10255,8 +10355,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10269,8 +10369,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10289,20 +10389,21 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "clap",
  "derive_more",
+ "fixed-map",
  "serde",
  "strum 0.27.2",
 ]
 
 [[package]]
 name = "reth-storage-api"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10320,12 +10421,13 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm-database",
+ "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10340,8 +10442,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10358,8 +10460,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10374,8 +10476,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10384,8 +10486,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "clap",
  "eyre",
@@ -10395,18 +10497,19 @@ dependencies = [
  "tracing-appender",
  "tracing-journald",
  "tracing-logfmt",
+ "tracing-samply",
  "tracing-subscriber 0.3.22",
- "url",
 ]
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "clap",
  "eyre",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -10418,8 +10521,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10458,8 +10561,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10469,6 +10572,7 @@ dependencies = [
  "auto_impl",
  "itertools 0.14.0",
  "metrics",
+ "parking_lot",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -10483,8 +10587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10510,21 +10614,23 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
  "reth-execution-errors",
  "reth-primitives-traits",
+ "reth-storage-api",
+ "reth-storage-errors",
  "reth-trie",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10548,8 +10654,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10567,8 +10673,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10585,17 +10691,17 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.9.3"
-source = "git+https://github.com/okx/reth?rev=3ba1e5d3820fff48ade7962769cb367ac183ba92#3ba1e5d3820fff48ade7962769cb367ac183ba92"
+version = "1.10.0"
+source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "31.0.2"
+version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb67a5223602113cae59a305acde2d9936bc18f2478dda879a6124b267cebfb6"
+checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -10624,9 +10730,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "11.0.2"
+version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92850e150f4f99d46c05a20ad0cd09286a7ad4ee21866fffb87101de6e602231"
+checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -10641,9 +10747,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "12.0.1"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d701e2c2347d65216b066489ab22a0a8e1f7b2568256110d73a7d5eff3385c"
+checksum = "431c9a14e4ef1be41ae503708fd02d974f80ef1f2b6b23b5e402e8d854d1b225"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -10684,9 +10790,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45418ed95cfdf0cb19effdbb7633cf2144cab7fb0e6ffd6b0eb9117a50adff6"
+checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -10703,9 +10809,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "12.0.2"
+version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99801eac7da06cc112df2244bd5a64024f4ef21240e923b26e73c4b4a0e5da6"
+checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
@@ -10721,9 +10827,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.32.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21caa99f22184a6818946362778cccd3ff02f743c1e085bee87700671570ecb7"
+checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10741,9 +10847,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "29.0.1"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22789ce92c5808c70185e3bc49732f987dc6fd907f77828c8d3470b2299c9c65"
+checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -10754,9 +10860,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "29.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968b124028960201abf6d6bf8e223f15fadebb4307df6b7dc9244a0aab5d2d05"
+checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12601,6 +12707,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-samply"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c175f7ecc002b6ef04776a39f440503e4e788790ddbdbfac8259b7a069526334"
+dependencies = [
+ "cfg-if",
+ "itoa",
+ "libc",
+ "mach2",
+ "memmap2",
+ "smallvec",
+ "tracing-core",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13892,6 +14014,7 @@ dependencies = [
  "metrics",
  "metrics-derive",
  "once_cell",
+ "op-alloy-network",
  "op-rbuilder",
  "reqwest",
  "reth",
@@ -13969,7 +14092,6 @@ dependencies = [
  "reth-errors",
  "reth-evm",
  "reth-optimism-rpc",
- "reth-revm",
  "reth-rpc",
  "reth-rpc-eth-api",
  "reth-storage-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.92"
 license = "MIT"
 homepage = "https://github.com/okx/xlayer-reth.git"
 repository = "https://github.com/okx/xlayer-reth.git"
@@ -70,95 +70,95 @@ xlayer-version = { path = "crates/version" }
 # ==============================================================================
 # Reth Dependencies (points to our fork)
 # ==============================================================================
-reth = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-chain-state = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-chainspec = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-cli = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-cli-commands = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-cli-util = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-db = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-db-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-errors = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-ethereum-forks = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-evm = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-exex = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-execution-types = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-builder = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-core = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-types = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-node = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-primitives = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-provider = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-revm = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-convert = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-eth-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-storage-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-tasks = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-tracing = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-flashblocks = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-server-types = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
+reth = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-chain-state = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-cli-commands = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-cli-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-db = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-db-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-errors = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-ethereum-forks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-exex = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-execution-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-core = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-node = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-provider = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-revm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-convert = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-eth-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-storage-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-tasks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-tracing = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-flashblocks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-server-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
 
 
 # ==============================================================================
 # Revm Dependencies (follows upstream reth)
 # ==============================================================================
-revm = { version = "31.0.2", default-features = false }
-revm-context-interface = { version = "12.0.1", default-features = false }
+revm = { version = "33.1.0", default-features = false }
+revm-context-interface = { version = "13.1.0", default-features = false }
 revm-database = { version = "9.0.5", default-features = false }
-revm-inspectors = { version = "0.32.0", default-features = false, features = [
+revm-inspectors = { version = "0.33.2", default-features = false, features = [
     "serde",
 ] }
 
 # ============================================================================== 
 # Flashblocks Dependencies
 # ============================================================================== 
-op-rbuilder = { git = "https://github.com/okx/op-rbuilder", tag = "v0.2.1" }
+op-rbuilder = { git = "https://github.com/okx/op-rbuilder", tag = "v0.2.3" }
 
 # ==============================================================================
 # Alloy Dependencies
 # ==============================================================================
 alloy-chains = { version = "0.2.20", default-features = false }
-alloy-consensus = { version = "1.0.41" }
-alloy-eips = { version = "1.0.41", default-features = false }
-alloy-evm = { version = "0.23.0", default-features = false }
-alloy-genesis = { version = "1.0.41", default-features = false }
+alloy-consensus = { version = "1.4.3" }
+alloy-eips = { version = "1.4.3", default-features = false }
+alloy-evm = { version = "0.25.1", default-features = false }
+alloy-genesis = { version = "1.4.3", default-features = false }
 alloy-json-rpc = { version = "1.1.0" }
 alloy-network = { version = "1.1.0", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false, features = [
     "map-foldhash",
 ] }
-alloy-provider = { version = "1.0.41" }
+alloy-provider = { version = "1.4.3" }
 alloy-rlp = { version = "0.3.10", default-features = false, features = [
     "core-net",
 ] }
 alloy-rpc-client = { version = "1.1.0" }
-alloy-rpc-types-engine = { version = "1.0.41", default-features = false }
-alloy-rpc-types-eth = { version = "1.0.41" }
-alloy-rpc-types-trace = { version = "1.0.41" }
+alloy-rpc-types-engine = { version = "1.4.3", default-features = false }
+alloy-rpc-types-eth = { version = "1.4.3" }
+alloy-rpc-types-trace = { version = "1.4.3" }
 alloy-signer = { version = "1.1.0", default-features = false }
 alloy-signer-local = { version = "1.1.0", default-features = false }
 alloy-sol-types = { version = "1.4.1", default-features = false }
 alloy-transport-http = { version = "1.1.0" }
 
 # op-alloy
-op-alloy-consensus = { version = "0.22.0", default-features = false }
-op-alloy-network = { version = "0.22.0", default-features = false }
-op-alloy-rpc-jsonrpsee = { version = "0.22.0", default-features = false }
-op-alloy-rpc-types = { version = "0.22.0", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.22.0", default-features = false }
+op-alloy-consensus = { version = "0.23.1", default-features = false }
+op-alloy-network = { version = "0.23.1", default-features = false }
+op-alloy-rpc-jsonrpsee = { version = "0.23.1", default-features = false }
+op-alloy-rpc-types = { version = "0.23.1", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.23.1", default-features = false }
 
 # ==============================================================================
 # Support Dependencies
@@ -202,55 +202,55 @@ moka = { version = "0.12.11", features = ["sync"] }
 # ==============================================================================
 # Redirects all paradigmxyz/reth dependencies to okx/reth fork for op-rbuilder.
 [patch."https://github.com/paradigmxyz/reth"]
-reth = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-basic-payload-builder = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-chain-state = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-chainspec = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-cli = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-cli-commands = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-cli-util = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-db = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-db-common = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-errors = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-evm = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-evm-ethereum = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-exex = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-execution-errors = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-execution-types = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-ipc = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-metrics = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-network-peers = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-builder = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-core = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-node-ethereum = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-node = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-payload-builder = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-payload-builder = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-payload-builder-primitives = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-payload-primitives = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-payload-util = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-primitives = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-provider = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-revm = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-engine-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-rpc-layer = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-storage-api = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-tasks = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-testing-utils = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-tracing-otlp = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-trie = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-trie-db = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
-reth-trie-parallel = { git = "https://github.com/okx/reth", rev = "3ba1e5d3820fff48ade7962769cb367ac183ba92" }
+reth = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-basic-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-chain-state = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-cli-commands = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-cli-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-db = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-db-common = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-errors = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-evm-ethereum = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-exex = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-execution-errors = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-execution-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-ipc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-metrics = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-network-peers = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-core = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-node-ethereum = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-node = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-payload-builder-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-payload-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-payload-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-provider = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-revm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-engine-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-rpc-layer = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-storage-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-tasks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-testing-utils = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-tracing-otlp = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-trie = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-trie-db = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth-trie-parallel = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -50,6 +50,7 @@ reqwest.workspace = true
 
 # rpc
 jsonrpsee.workspace = true
+op-alloy-network.workspace = true
 
 # alloy
 alloy-primitives.workspace = true

--- a/crates/flashblocks/src/pubsub.rs
+++ b/crates/flashblocks/src/pubsub.rs
@@ -58,10 +58,10 @@ pub enum FlashblockParams {
 impl FlashblockParams {
     /// Validates the flashblock params.
     pub fn validate(&self, max_subscribed_addresses: usize) -> Result<(), ErrorObject<'static>> {
-        if let FlashblockParams::FlashblocksFilter(filter) = self {
-            if filter.sub_tx_filter.subscribe_addresses.len() > max_subscribed_addresses {
-                return Err(invalid_params_rpc_err("too many subscribe addresses"));
-            }
+        if let FlashblockParams::FlashblocksFilter(filter) = self
+            && filter.sub_tx_filter.subscribe_addresses.len() > max_subscribed_addresses
+        {
+            return Err(invalid_params_rpc_err("too many subscribe addresses"));
         }
         Ok(())
     }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -15,7 +15,6 @@ reth-chainspec.workspace = true
 reth-errors.workspace = true
 reth-evm.workspace = true
 reth-optimism-rpc.workspace = true
-reth-revm.workspace = true
 reth-rpc.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-storage-api.workspace = true

--- a/crates/rpc/src/pre_exec_ext_xlayer.rs
+++ b/crates/rpc/src/pre_exec_ext_xlayer.rs
@@ -15,8 +15,9 @@ use reth_rpc_eth_api::{
     helpers::{Call, LoadState, SpawnBlocking, Trace},
     EthApiTypes, RpcTypes,
 };
+use revm::context::result::ExecutionResult;
 use revm::context_interface::block::Block; // for block_env.number()
-use revm::{context_interface::result::ExecutionResult, DatabaseCommit};
+use revm::DatabaseCommit;
 use revm_inspectors::tracing::MuxInspector;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
@@ -327,7 +328,7 @@ pub trait PreExec: EthCall {
 
             pre_exec_res.error = match exec.result {
                 ExecutionResult::Success { .. } => PreExecError::default(),
-                ExecutionResult::Revert { output, .. } => {
+                ExecutionResult::Revert { output, gas_used: _ } => {
                     PreExecError::reverted(format!("execution reverted: 0x{}", hex::encode(output)))
                 }
                 ExecutionResult::Halt { reason, .. } => Self::classify_error(format!("{reason:?}")),

--- a/crates/rpc/src/xlayer_ext.rs
+++ b/crates/rpc/src/xlayer_ext.rs
@@ -156,11 +156,7 @@ where
 
         let api = self.backend.clone();
         self.backend
-            .spawn_with_state_at_block(at, move |state| {
-                let mut db = reth_revm::db::CacheDB::new(
-                    reth_revm::database::StateProviderDatabase::new(state),
-                );
-
+            .spawn_with_state_at_block(at, move |_state, mut db| {
                 if let Some(overrides) = state_overrides
                     && let Err(e) = apply_state_overrides(overrides, &mut db)
                 {

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -42,7 +42,7 @@ derive_more.workspace = true
 [dev-dependencies]
 rstest = "0.23"
 scopeguard = "1.2"
-alloy-rpc-types-engine = { version = "1.0.41", default-features = false }
+alloy-rpc-types-engine = { version = "1.4.3", default-features = false }
 
 [lib]
 name = "xlayer_e2e_test"


### PR DESCRIPTION
This PR sees the upgrade using latest tag v1.10.0 which modifies some APIs used by our node.

Key highlights:
* upstream reth **v1.10.0** + 2 cherry-picked commits (see [here](https://github.com/okx/reth/commits/upstream/dev-v1.10.0/))
* bump base rust version to **1.92** (following op-rbuilder in flashblocks crate)
* bump op-rbuilder to **0.2.3**