### PR TITLE
build: fix docker build, align cargo chef base image with latest rust toolchain version

### DIFF
--- a/DockerfileOp
+++ b/DockerfileOp
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.92 AS chef
 WORKDIR /app
 
 LABEL org.opencontainers.image.source=https://github.com/xlayer/xlayer-reth


### PR DESCRIPTION
## Summary

Resolves the failing docker build by fixing the base image cargo chef version used. Align the base image cargo chef version to use the current rust toolchain version v1.92