### PR TITLE
fix(rpc): add trace_address for delegatecall and fix address format c…

### DIFF
--- a/crates/rpc/src/pre_exec_ext_xlayer.rs
+++ b/crates/rpc/src/pre_exec_ext_xlayer.rs
@@ -204,6 +204,10 @@ pub mod helpers {
         if !frame.calls.is_empty() {
             let next_root =
                 if depth == 0 { String::new() } else { format!("{depth_index_root}_{index}") };
+            // For delegatecall, caller (msg.sender) stays the same, so pass parent_from unchanged
+            // For other call types, the current frame becomes the new caller
+            let is_delegatecall = frame.typ.to_string().to_lowercase() == "delegatecall";
+            let next_parent_from = if is_delegatecall { parent_from } else { Some(frame.from) };
             for (i, nested) in frame.calls.iter().enumerate() {
                 let parent_err = out.last().map(|x| x.is_error).unwrap_or(false);
                 convert_call_frame_recursive(
@@ -213,7 +217,7 @@ pub mod helpers {
                     i as i64,
                     next_root.clone(),
                     parent_err,
-                    Some(frame.from),
+                    next_parent_from,
                 );
             }
         }


### PR DESCRIPTION
### Problem

The `trace_address` field was missing for `delegatecall` inner transactions.

### Changes

- Set `trace_address` for `delegatecall` to the caller address (`frame.from`)
- Use 32-byte hash format for address fields (64 hex characters)

### Why trace_address for delegatecall?

`DELEGATECALL` executes code from another contract while preserving the original `msg.sender`. The `trace_address` field records which contract initiated the delegatecall, which is essential for tracing the actual call chain in proxy contract patterns.