### PR TITLE
feat: add subscriber limit after interface change

### DIFF
--- a/crates/flashblocks/src/handler.rs
+++ b/crates/flashblocks/src/handler.rs
@@ -1,6 +1,7 @@
 use op_rbuilder::args::OpRbuilderArgs;
 use op_rbuilder::builders::WebSocketPublisher;
 use op_rbuilder::metrics::OpRBuilderMetrics;
+use op_rbuilder::tokio_metrics::FlashblocksTaskMetrics;
 use reth_node_api::FullNodeComponents;
 use reth_optimism_flashblocks::FlashBlockRx;
 use std::net::SocketAddr;
@@ -32,9 +33,15 @@ where
         );
 
         let metrics = Arc::new(OpRBuilderMetrics::default());
+        let task_metrics = Arc::new(FlashblocksTaskMetrics::new());
         let ws_pub = Arc::new(
-            WebSocketPublisher::new(ws_addr, metrics, op_args.flashblocks.ws_subscriber_limit)
-                .map_err(|e| eyre::eyre!("Failed to create WebSocket publisher: {e}"))?,
+            WebSocketPublisher::new(
+                ws_addr,
+                metrics,
+                &task_metrics.websocket_publisher,
+                op_args.flashblocks.ws_subscriber_limit,
+            )
+            .map_err(|e| eyre::eyre!("Failed to create WebSocket publisher: {e}"))?,
         );
 
         info!(target: "flashblocks", "WebSocket publisher initialized at {}", ws_addr);


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Code Guidelines
Before submitting your PR, please review the relevant code guidelines in the `docs/` folder:

- **[Building on Reth Guide](../docs/BUILDING_ON_RETH.md)** - Comprehensive guide for building on top of Reth

### Specific Guidelines by Component:
- **[Chainspec & EVM Guide](../docs/subguides/CHAINSPEC_EVM_GUIDE.md)** - For changes to chainspec or EVM configuration
- **[Database Guide](../docs/subguides/DATABASE_GUIDE.md)** - For changes to database tables or storage
- **[Engine & Consensus Guide](../docs/subguides/ENGINE_CONSENSUS_GUIDE.md)** - For changes to consensus or engine API
- **[Extension Guide](../docs/subguides/EXTENSION_GUIDE.md)** - For adding extensions or plugins
- **[Node Builder Guide](../docs/subguides/NODE_BUILDER_GUIDE.md)** - For changes to node initialization
- **[Payload Builder Guide](../docs/subguides/PAYLOAD_BUILDER_GUIDE.md)** - For changes to block building logic

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] I have reviewed the relevant code guidelines in the `docs/` folder
- [ ] My code follows the coding standards of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Testing
<!-- Describe the tests you ran and how to reproduce them -->

## Additional Notes
<!-- Any additional information, context, or screenshots -->
