### PR TITLE
perf(full trace): Use on_block_build_start hook instead of on_fork_choice_updated

### DIFF
--- a/crates/full-trace/src/tracer.rs
+++ b/crates/full-trace/src/tracer.rs
@@ -1,9 +1,6 @@
 //! Tracer for full trace support
 
 use alloy_primitives::B256;
-use alloy_rpc_types_engine::ForkchoiceState;
-use op_alloy_rpc_types_engine::OpExecutionData;
-use reth_node_api::EngineTypes;
 use std::sync::Arc;
 
 /// Block information for tracing.
@@ -41,32 +38,23 @@ where
         Arc::new(Self { xlayer_args })
     }
 
-    /// Handle fork choice updated events.
+    /// Handle block build start events.
     ///
-    /// This method is called when a fork choice update API is invoked (before execution).
-    /// Implement your custom tracing logic here.
+    /// This method is called when a block build process is initiated via fork choice update.
+    /// It is only called when payload attributes are present, indicating a new block is being built.
     ///
     /// # Parameters
     /// - `version`: The fork choice updated version (e.g., "v1", "v2", "v3")
-    /// - `state`: The fork choice state containing head, safe, and finalized block hashes
-    /// - `attrs`: Optional payload attributes for block building
-    pub fn on_fork_choice_updated<EngineT: EngineTypes<ExecutionData = OpExecutionData>>(
-        &self,
-        version: &str,
-        state: &ForkchoiceState,
-        _attrs: &Option<EngineT::PayloadAttributes>,
-    ) {
+    /// - `new_block_number`: The block number of the new block being built
+    pub fn on_block_build_start(&self, version: &str, new_block_number: u64) {
         tracing::info!(
-            target: "xlayer::full_trace::fork_choice_updated",
-            "Fork choice updated {} called: head={:?}, safe={:?}, finalized={:?}, has_attrs={}",
+            target: "xlayer::full_trace::block_build",
+            "Block build start {} called: new_block_number={}",
             version,
-            state.head_block_hash,
-            state.safe_block_hash,
-            state.finalized_block_hash,
-            _attrs.is_some()
+            new_block_number
         );
 
-        // TODO: add SeqBlockBuildStart here
+        // TODO: add SeqBlockBuildStart here, use xlayer_args if you want
     }
 
     /// Handle new payload events.


### PR DESCRIPTION
This pull request refactors the block tracing logic in `engine_api_tracer.rs` and `tracer.rs` to improve clarity and accuracy when tracking block build events. The main change is to trigger the tracer only when a new block is being built (i.e., when payload attributes are present), and to pass the new block number to the tracer. The tracer interface is updated to reflect this change, and supporting code is added to query the block number from the provider. Additionally, some type and field adjustments were made for better code organization.

### Tracing logic improvements

* The tracer is now called only when a new block is being built (when payload attributes are present), and the block number is passed to the tracer using the new `on_block_build_start` method instead of the previous `on_fork_choice_updated` method. This change is applied for fork choice updates v1, v2, and v3. [[1]](diffhunk://#diff-31970944b42961194723f7e3e8c31de2857d11647b0c684ae09796bfe547169eL190-R230) [[2]](diffhunk://#diff-31970944b42961194723f7e3e8c31de2857d11647b0c684ae09796bfe547169eL223-R270) [[3]](diffhunk://#diff-31970944b42961194723f7e3e8c31de2857d11647b0c684ae09796bfe547169eL256-R310) [[4]](diffhunk://#diff-e8dc2d5b27daef41078f036ea97cc887f18c185ad480a1f953187435be660d45L44-R57)
* Added a helper method `query_new_block_number` to query the block number from the provider, which is used to determine the new block number for tracing.

### API and interface changes

* The `Tracer` struct and its method were updated: removed the fork choice state and payload attributes arguments from the tracing method, and replaced them with the new block number.
* The `EngineApiTracer` struct now stores an optional provider for querying block information, with a setter method and updated phantom data usage. [[1]](diffhunk://#diff-31970944b42961194723f7e3e8c31de2857d11647b0c684ae09796bfe547169eR46-R51) [[2]](diffhunk://#diff-31970944b42961194723f7e3e8c31de2857d11647b0c684ae09796bfe547169eL60-R101) [[3]](diffhunk://#diff-31970944b42961194723f7e3e8c31de2857d11647b0c684ae09796bfe547169eR520-R521)

### Miscellaneous

* Added `warn` to the tracing imports to log warnings when block information cannot be queried.
* Cleaned up unused imports in `tracer.rs`.