### PR TITLE
fix(tools): check start block <= end block

### DIFF
--- a/bin/tools/export.rs
+++ b/bin/tools/export.rs
@@ -89,6 +89,14 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ExportCommand<C> {
         }
         let start_block = self.start_block;
 
+        if start_block > end_block {
+            return Err(eyre!(
+                "Start block ({}) is greater than end block ({})",
+                start_block,
+                end_block
+            ));
+        }
+
         let total_blocks = end_block - start_block + 1;
         info!(
             target: "reth::cli",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Code Guidelines
Before submitting your PR, please review the relevant code guidelines in the `docs/` folder:

- **[Building on Reth Guide](../docs/BUILDING_ON_RETH.md)** - Comprehensive guide for building on top of Reth

### Specific Guidelines by Component:
- **[Chainspec & EVM Guide](../docs/subguides/CHAINSPEC_EVM_GUIDE.md)** - For changes to chainspec or EVM configuration
- **[Database Guide](../docs/subguides/DATABASE_GUIDE.md)** - For changes to database tables or storage
- **[Engine & Consensus Guide](../docs/subguides/ENGINE_CONSENSUS_GUIDE.md)** - For changes to consensus or engine API
- **[Extension Guide](../docs/subguides/EXTENSION_GUIDE.md)** - For adding extensions or plugins
- **[Node Builder Guide](../docs/subguides/NODE_BUILDER_GUIDE.md)** - For changes to node initialization
- **[Payload Builder Guide](../docs/subguides/PAYLOAD_BUILDER_GUIDE.md)** - For changes to block building logic

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have reviewed the relevant code guidelines in the `docs/` folder
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing
<!-- Describe the tests you ran and how to reproduce them -->

Previously:
```
$ xlayer-reth-tools export --exported-data exp.rlp --start-block 10 --end-block 0
...
2026-01-23T08:38:26.351461Z  INFO Exporting blocks 10 to 0 (18446744073709551607 blocks total)
2026-01-23T08:38:26.351504Z  INFO Export complete! Exported 0 blocks to exp.rlp
```

After fix:
```
$ xlayer-reth-tools export --exported-data exp.rlp --start-block 10 --end-block 0
...
2026-01-23T08:41:30.923853Z  INFO Verifying storage consistency.
2026-01-23T08:41:30.924111Z ERROR Error: "Start block (10) is greater than end block (0)"
```

## Additional Notes
<!-- Any additional information, context, or screenshots -->
