### PR TITLE
remove exported output file on error

### DIFF
--- a/bin/tools/export.rs
+++ b/bin/tools/export.rs
@@ -130,76 +130,89 @@ impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> ExportCommand<C> {
             Box::new(output_file)
         };
 
-        // Export blocks in batches
-        let mut current_block = start_block;
-        let mut exported_blocks = 0u64;
+        // Export blocks in batches - wrap in closure to handle cleanup on error
+        let export_result = (|| -> Result<()> {
+            let mut current_block = start_block;
+            let mut exported_blocks = 0u64;
 
-        while current_block <= end_block && !shutdown.load(Ordering::SeqCst) {
-            let batch_end = std::cmp::min(current_block + self.batch_size - 1, end_block);
+            while current_block <= end_block && !shutdown.load(Ordering::SeqCst) {
+                let batch_end = std::cmp::min(current_block + self.batch_size - 1, end_block);
 
-            match provider.block_range(current_block..=batch_end) {
-                Ok(blocks) => {
-                    let blocks_rlp: Vec<Vec<u8>> = blocks
-                        .into_par_iter()
-                        .map(|block| {
-                            let mut rlp_buf = Vec::new();
-                            block.encode(&mut rlp_buf);
-                            rlp_buf
-                        })
-                        .collect();
-                    let blocks_rlp_concat = blocks_rlp.concat();
+                match provider.block_range(current_block..=batch_end) {
+                    Ok(blocks) => {
+                        let blocks_rlp: Vec<Vec<u8>> = blocks
+                            .into_par_iter()
+                            .map(|block| {
+                                let mut rlp_buf = Vec::new();
+                                block.encode(&mut rlp_buf);
+                                rlp_buf
+                            })
+                            .collect();
+                        let blocks_rlp_concat = blocks_rlp.concat();
 
-                    writer.write_all(&blocks_rlp_concat).wrap_err_with(|| {
-                        format!(
-                            "Failed to write block range {current_block} to {batch_end} to file"
-                        )
-                    })?;
+                        writer.write_all(&blocks_rlp_concat).wrap_err_with(|| {
+                            format!(
+                                "Failed to write block range {current_block} to {batch_end} to file"
+                            )
+                        })?;
+                    }
+                    Err(e) => {
+                        error!(target: "reth::cli", "Error: {:#?}", e);
+                        return Err(eyre!(e));
+                    }
                 }
-                Err(e) => {
-                    error!(target: "reth::cli", "Error: {:#?}", e);
-                    return Err(eyre!(e));
+
+                exported_blocks += batch_end - current_block + 1;
+
+                // Log progress periodically
+                if exported_blocks.is_multiple_of(self.batch_size) {
+                    let progress = (exported_blocks as f64 / total_blocks as f64) * 100.0;
+                    info!(
+                        target: "reth::cli",
+                        "Exported {} blocks ({:.2}%)",
+                        exported_blocks,
+                        progress
+                    );
                 }
+
+                current_block = batch_end + 1;
             }
 
-            exported_blocks += batch_end - current_block + 1;
+            // Flush and close the writer
+            writer.flush().wrap_err("Failed to flush output file")?;
 
-            // Log progress periodically
-            if exported_blocks.is_multiple_of(self.batch_size) {
-                let progress = (exported_blocks as f64 / total_blocks as f64) * 100.0;
-                info!(
+            if shutdown.load(Ordering::SeqCst) {
+                warn!(
                     target: "reth::cli",
-                    "Exported {} blocks ({:.2}%)",
+                    "Export interrupted! Exported {}/{} blocks",
                     exported_blocks,
-                    progress
+                    total_blocks
                 );
+                return Err(eyre!(
+                    "Export was interrupted. Exported {}/{} blocks",
+                    exported_blocks,
+                    total_blocks
+                ));
             }
 
-            current_block = batch_end + 1;
-        }
-
-        // Flush and close the writer
-        writer.flush().wrap_err("Failed to flush output file")?;
-
-        if shutdown.load(Ordering::SeqCst) {
-            warn!(
+            info!(
                 target: "reth::cli",
-                "Export interrupted! Exported {}/{} blocks",
+                "Export complete! Exported {} blocks to {}",
                 exported_blocks,
-                total_blocks
+                self.output_path.display()
             );
-            return Err(eyre!(
-                "Export was interrupted. Exported {}/{} blocks",
-                exported_blocks,
-                total_blocks
-            ));
-        }
 
-        info!(
-            target: "reth::cli",
-            "Export complete! Exported {} blocks to {}",
-            exported_blocks,
-            self.output_path.display()
-        );
+            Ok(())
+        })();
+
+        // If an error occurred, remove the output file
+        if let Err(e) = export_result {
+            warn!(target: "reth::cli", "Removing incomplete output file: {}", self.output_path.display());
+            if let Err(remove_err) = std::fs::remove_file(&self.output_path) {
+                warn!(target: "reth::cli", "Failed to remove output file: {}", remove_err);
+            }
+            return Err(e);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

### Issue
The export command creates the output file before executing any export work, then returns early on errors, e.g., failed block reads, interrupts, or invalid ranges, without removing or rolling back the newly created file. When the export loop is skipped or aborted, it leaves behind an empty or partial file. At the same time, the command still appears to have produced an artifact, increasing the likelihood that operators will treat incomplete exports as valid backups.Consider ensuring that any early-return path removes the partially created file so that failed exports do not leave behind misleading artifacts.

### Fix
We modified the execute() function to remove the output file if an error occurs. We wrap the main logic in a closure block and add cleanup logic on error (file bin/toolsexport.rs).

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Code Guidelines
Before submitting your PR, please review the relevant code guidelines in the `docs/` folder:

- **[Building on Reth Guide](../docs/BUILDING_ON_RETH.md)** - Comprehensive guide for building on top of Reth

### Specific Guidelines by Component:
- **[Chainspec & EVM Guide](../docs/subguides/CHAINSPEC_EVM_GUIDE.md)** - For changes to chainspec or EVM configuration
- **[Database Guide](../docs/subguides/DATABASE_GUIDE.md)** - For changes to database tables or storage
- **[Engine & Consensus Guide](../docs/subguides/ENGINE_CONSENSUS_GUIDE.md)** - For changes to consensus or engine API
- **[Extension Guide](../docs/subguides/EXTENSION_GUIDE.md)** - For adding extensions or plugins
- **[Node Builder Guide](../docs/subguides/NODE_BUILDER_GUIDE.md)** - For changes to node initialization
- **[Payload Builder Guide](../docs/subguides/PAYLOAD_BUILDER_GUIDE.md)** - For changes to block building logic

## Checklist
<!-- Mark completed items with an "x" -->
- [x] I have reviewed the relevant code guidelines in the `docs/` folder
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing
<!-- Describe the tests you ran and how to reproduce them -->

Previously:
- create a local devnet using xlayer-toolkit
- run:
```
xlayer-reth-tools export --datadir /home/ubuntu/git/XLayer/xlayer-toolkit/devnet/data/op-reth-seq --exported-data 
exported.rlp
...
2026-01-26T02:26:03.885564Z ERROR Error: Other(
    FileSystem(
        Open {
            source: Os {
                code: 2,
                kind: NotFound,
                message: "No such file or directory",
            },
            path: "xlayer-toolkit/devnet/data/op-reth-seq/static_files/static_file_headers_0_499999.conf",
        },
    ),
)
```
- but the output file is still created:
exported.rlp 0 bytes

After fix:
- we get the same error but no file is created
