### PR TITLE
perf(rpc): Replace magic error code number to INTERNAL_ERROR_CODE

### DIFF
--- a/crates/rpc/src/xlayer_ext.rs
+++ b/crates/rpc/src/xlayer_ext.rs
@@ -5,6 +5,7 @@ use alloy_primitives::U256;
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
+    types::error::INTERNAL_ERROR_CODE,
 };
 use tracing::{debug, warn};
 
@@ -85,7 +86,7 @@ where
         // Local calculation (sequencer mode or fallback)
         let header = self.backend.provider().latest_header().map_err(|err| {
             jsonrpsee::types::ErrorObjectOwned::owned(
-                -32603,
+                INTERNAL_ERROR_CODE,
                 format!("Failed to get latest header: {err}"),
                 None::<()>,
             )


### PR DESCRIPTION
This pull request makes a minor improvement to error handling in the `crates/rpc/src/xlayer_ext.rs` file by replacing a hardcoded error code with a named constant for better readability and maintainability.

- Error Handling Improvement:
  * Replaced the hardcoded JSON-RPC error code `-32603` with the `INTERNAL_ERROR_CODE` constant from `jsonrpsee::types::error` for consistency and clarity in error responses. [[1]](diffhunk://#diff-5eefa4e44af227acee291aa1738d027ffa3e1b63fb26ba1ce76aceabfedee14bR8) [[2]](diffhunk://#diff-5eefa4e44af227acee291aa1738d027ffa3e1b63fb26ba1ce76aceabfedee14bL88-R89)