### PR TITLE
chore: upgrade reth v1.10.2 and op-rbuilder v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3a72a2247c34a8545ee99e562b1b9b69168e5000567257ae51e91b4e6b1193"
+checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3a590d13de3944675987394715f37537b50b856e3b23a0e66e97d963edbf38"
+checksum = "ed1958f0294ecc05ebe7b3c9a8662a3e221c2523b7f2bcd94c7a651efbd510bf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f28f769d5ea999f0d8a105e434f483456a15b4e1fcb08edbbbe1650a497ff6d"
+checksum = "f752e99497ddc39e22d547d7dfe516af10c979405a034ed90e69b914b7dddeae"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990fa65cd132a99d3c3795a82b9f93ec82b81c7de3bab0bf26ca5c73286f7186"
+checksum = "f2140796bc79150b1b7375daeab99750f0ff5e27b1f8b0aa81ccde229c7f02a2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369f5707b958927176265e8a58627fc6195e5dfa5c55689396e68b241b3a72e6"
+checksum = "787cb8baf0e681d995c4a4d49713d56b91083930ae42d5d277a07276cafbe76f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -238,24 +238,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.1.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926b2c0d34e641cf8b17bf54ce50fda16715b9f68ad878fa6128bae410c6f890"
+checksum = "d3231de68d5d6e75332b7489cfcc7f4dfabeba94d990a10e4b923af0e6623540"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09535cbc646b0e0c6fcc12b7597eaed12cf86dff4c4fba9507a61e71b94f30eb"
+checksum = "813a67f87e56b38554d18b182616ee5006e8e2bf9df96a0df8bf29dff1d52e3f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -275,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.25.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ccc4c702c840148af1ce784cc5c6ed9274a020ef32417c5b1dbeab8c317673"
+checksum = "a96827207397445a919a8adc49289b53cc74e48e460411740bba31cec2fc307d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -297,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005520ccf89fa3d755e46c1d992a9e795466c2e7921be2145ef1f749c5727de"
+checksum = "05864eef929c4d28895ae4b4d8ac9c6753c4df66e873b9c8fafc8089b59c1502"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -326,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e3cf01219c966f95a460c95f1d4c30e12f6c18150c21a30b768af2a2a29142"
+checksum = "dad32d0724b70717ce15a76b48f11a4438010b85a90f728f476e99d5a6b06379"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -338,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b626409c98ba43aaaa558361bca21440c88fd30df7542c7484b9c7a1489cdb"
+checksum = "d2dd146b3de349a6ffaa4e4e319ab3a90371fb159fb0bddeb1c7bbe8b1792eff"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -353,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89924fdcfeee0e0fa42b1f10af42f92802b5d16be614a70897382565663bf7cf"
+checksum = "8c12278ffbb8872dfba3b2f17d8ea5e8503c2df5155d9bc5ee342794bde505c3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -379,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0dbe56ff50065713ff8635d8712a0895db3ad7f209db9793ad8fcb6b1734aa"
+checksum = "833037c04917bc2031541a60e8249e4ab5500e24c637c1c62e95e963a655d66f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -392,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-evm"
-version = "0.25.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f640da852f93ddaa3b9a602b7ca41d80e0023f77a67b68aaaf511c32f1fe0ce"
+checksum = "54dc5c46a92fc7267055a174d30efb34e2599a0047102a4d38a025ae521435ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -422,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
+checksum = "f1841ce147fa6cfdeb6b7751e2583b605bb8eef4238a2d3e0880b5cb3aba0e83"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -449,14 +452,13 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sha3",
- "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b56f7a77513308a21a2ba0e9d57785a9d9d2d609e77f4e71a78a1192b83ff2d"
+checksum = "eafa840b0afe01c889a3012bb2fde770a544f74eab2e2870303eb0a5fb869c48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -500,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94813abbd7baa30c700ea02e7f92319dbcb03bff77aeea92a3a9af7ba19c5c70"
+checksum = "57b3a3b3e4efc9f4d30e3326b6bd6811231d16ef94837e18a802b44ca55119e6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -544,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff01723afc25ec4c5b04de399155bef7b6a96dfde2475492b1b7b4e7a4f46445"
+checksum = "12768ae6303ec764905a8a7cd472aea9072f9f9c980d18151e26913da8ae0123"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -570,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91bf006bb06b7d812591b6ac33395cb92f46c6a65cda11ee30b348338214f0f"
+checksum = "0622d8bcac2f16727590aa33f4c3f05ea98130e7e4b4924bce8be85da5ad0dae"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -583,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b934c3bcdc6617563b45deb36a40881c8230b94d0546ea739dff7edb3aa2f6fd"
+checksum = "c38c5ac70457ecc74e87fe1a5a19f936419224ded0eb0636241452412ca92733"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -595,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e82145856df8abb1fefabef58cdec0f7d9abf337d4abd50c1ed7e581634acdd"
+checksum = "ae8eb0e5d6c48941b61ab76fabab4af66f7d88309a98aa14ad3dec7911c1eba3"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -607,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212ca1c1dab27f531d3858f8b1a2d6bfb2da664be0c1083971078eb7b71abe4b"
+checksum = "a1cf5a093e437dfd62df48e480f24e1a3807632358aad6816d7a52875f1c04aa"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -618,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d92a9b4b268fac505ef7fb1dac9bb129d4fd7de7753f22a5b6e9f666f7f7de6"
+checksum = "e07949e912479ef3b848e1cf8db54b534bdd7bc58e6c23f28ea9488960990c8c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -638,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab1ebed118b701c497e6541d2d11dfa6f3c6ae31a3c52999daa802fcdcc16b7"
+checksum = "925ff0f48c2169c050f0ae7a82769bdf3f45723d6742ebb6a5efb4ed2f491b26"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -650,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232f00fcbcd3ee3b9399b96223a8fc884d17742a70a44f9d7cef275f93e6e872"
+checksum = "336ef381c7409f23c69f6e79bddc1917b6e832cff23e7a5cf84b9381d53582e6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -670,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5715d0bf7efbd360873518bd9f6595762136b5327a9b759a8c42ccd9b5e44945"
+checksum = "28e97603095020543a019ab133e0e3dc38cd0819f19f19bdd70c642404a54751"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -692,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b61941d2add2ee64646612d3eda92cbbde8e6c933489760b6222c8898c79be"
+checksum = "2805153975e25d38e37ee100880e642d5b24e421ed3014a7d2dae1d9be77562e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -707,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763cc931a28682bd4b9a68af90057b0fbe80e2538a82251afd69d7ae00bbebf"
+checksum = "f1aec4e1c66505d067933ea1a949a4fb60a19c4cfc2f109aa65873ea99e62ea8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -721,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359a8caaa98cb49eed62d03f5bc511dd6dd5dee292238e8627a6e5690156df0f"
+checksum = "25b73c1d6e4f1737a20d246dad5a0abd6c1b76ec4c3d153684ef8c6f1b6bb4f4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -733,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed8531cae8d21ee1c6571d0995f8c9f0652a6ef6452fde369283edea6ab7138"
+checksum = "946a0d413dbb5cd9adba0de5f8a1a34d5b77deda9b69c1d7feed8fc875a1aa26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -745,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb10ccd49d0248df51063fce6b716f68a315dd912d55b32178c883fd48b4021d"
+checksum = "2f7481dc8316768f042495eaf305d450c32defbc9bce09d8bf28afcd956895bb"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -760,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d992d44e6c414ece580294abbadb50e74cfd4eaa69787350a4dfd4b20eaa1b"
+checksum = "1259dac1f534a4c66c1d65237c89915d0010a2a91d6c3b0bada24dc5ee0fb917"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -779,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09eb18ce0df92b4277291bbaa0ed70545d78b02948df756bbd3d6214bf39a218"
+checksum = "25d4b140adc0e4f7bd2b4928d2772fbdf4db114312c4619eff08eba7b6440b9e"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -793,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d9fa2daf21f59aa546d549943f10b5cce1ae59986774019fbedae834ffe01b"
+checksum = "0512730c0658dab978c9706b592c378974fe49cd14614083a37f7f396aaf2eb5"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -812,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9396007fe69c26ee118a19f4dee1f5d1d6be186ea75b3881adf16d87f8444686"
+checksum = "b7f5b5f9e6fc8af3420d527cab5eecddc9c437227df251b3c7eb70b0941d8bd5"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -830,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67a0b0dcebe14244fc92002cd8d96ecbf65db4639d479f5fcd5805755a4c27"
+checksum = "d6dbdf239d997b705e1c23cc8bb43f301db615b187379fa923d87723d47fcd31"
 dependencies = [
  "serde",
  "winnow",
@@ -840,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aeea64f09a7483bdcd4193634c7e5cf9fd7775ee767585270cd8ce2d69dc95"
+checksum = "67a8a2c35dbb545c6945b933957556693839df252c712194bf201c9e528670a3"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -852,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50a9516736d22dd834cc2240e5bf264f338667cc1d9e514b55ec5a78b987ca"
+checksum = "78f169b85eb9334871db986e7eaf59c58a03d86a30cc68b846573d47ed0656bb"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -875,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a18b541a6197cf9a084481498a766fdf32fefda0c35ea6096df7d511025e9f1"
+checksum = "019821102e70603e2c141954418255bec539ef64ac4117f8e84fb493769acf73"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -893,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8075911680ebc537578cacf9453464fd394822a0f68614884a9c63f9fbaf5e89"
+checksum = "e574ca2f490fb5961d2cdd78188897392c46615cd88b35c202d34bbc31571a81"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -913,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921d37a57e2975e5215f7dd0f28873ed5407c7af630d4831a4b5c737de4b0b8b"
+checksum = "b92dea6996269769f74ae56475570e3586910661e037b7b52d50c9641f76c68f"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -950,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2289a842d02fe63f8c466db964168bb2c7a9fdfb7b24816dbb17d45520575fb"
+checksum = "45ceac797eb8a56bdf5ab1fab353072c17d472eab87645ca847afe720db3246d"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -1542,12 +1544,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "az"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,13 +2099,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2117,12 +2123,12 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.3.2",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2155,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2254,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "3e34525d5bbbd55da2bb745d34b36121baac88d07619a9a09cfcf4a6c0832785"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2264,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "59a20016a20a3da95bef50ec7238dbd09baeef4311dcdd38ec15aba69812fb61"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2276,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3548,9 +3554,9 @@ checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fixed-cache"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d3af83468398d500e9bc19e001812dcb1a11e4d3d6a5956c789aa3c11a8cb5"
+checksum = "0aaafa7294e9617eb29e5c684a3af33324ef512a1bf596af2d1938a03798da29"
 dependencies = [
  "equivalent",
 ]
@@ -3935,16 +3941,6 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4336,7 +4332,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4361,9 +4357,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5030,9 +5026,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5094,9 +5090,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libp2p"
@@ -5435,7 +5431,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tracing",
 ]
@@ -5842,9 +5838,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -6061,9 +6057,12 @@ dependencies = [
 
 [[package]]
 name = "notify-types"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -6119,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -6384,7 +6383,7 @@ dependencies = [
 [[package]]
 name = "op-rbuilder"
 version = "0.3.0"
-source = "git+https://github.com/okx/op-rbuilder?tag=v0.2.5#79e67d4f895b01423f051da5c71d22be7025f7f6"
+source = "git+https://github.com/okx/op-rbuilder?tag=v0.3.0#c265ae82612dea0de73bccf9cb1ba0cf6cc4b2fc"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -6506,9 +6505,9 @@ dependencies = [
 
 [[package]]
 name = "op-revm"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1475a779c73999fc803778524042319691b31f3d6699d2b560c4ed8be1db802a"
+checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
 dependencies = [
  "auto_impl",
  "revm",
@@ -6684,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.3.0"
-source = "git+https://github.com/okx/op-rbuilder?tag=v0.2.5#79e67d4f895b01423f051da5c71d22be7025f7f6"
+source = "git+https://github.com/okx/op-rbuilder?tag=v0.3.0#c265ae82612dea0de73bccf9cb1ba0cf6cc4b2fc"
 dependencies = [
  "derive_more",
  "eyre",
@@ -7295,7 +7294,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7332,16 +7331,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -7688,8 +7687,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -7734,8 +7733,8 @@ dependencies = [
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7758,8 +7757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7779,8 +7778,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-trie",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0",
+ "revm-state 9.0.0",
  "serde",
  "tokio",
  "tokio-stream",
@@ -7789,8 +7788,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7809,8 +7808,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7823,8 +7822,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7901,8 +7900,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7911,8 +7910,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7929,8 +7928,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7949,8 +7948,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7959,8 +7958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7975,8 +7974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7988,8 +7987,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8000,8 +7999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8026,8 +8025,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8052,8 +8051,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8080,8 +8079,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8110,8 +8109,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8125,8 +8124,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8150,8 +8149,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8174,8 +8173,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -8198,8 +8197,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8229,8 +8228,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -8257,8 +8256,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8282,8 +8281,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8307,8 +8306,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "futures",
  "pin-project",
@@ -8325,12 +8324,13 @@ dependencies = [
  "reth-prune",
  "reth-stages-api",
  "reth-tasks",
+ "reth-trie-db",
 ]
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8367,11 +8367,13 @@ dependencies = [
  "reth-stages-api",
  "reth-tasks",
  "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "reth-trie-sparse-parallel",
  "revm",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "schnellru",
  "smallvec",
  "thiserror 2.0.18",
@@ -8381,8 +8383,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8409,8 +8411,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8424,8 +8426,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8440,8 +8442,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8462,8 +8464,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8473,8 +8475,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8501,8 +8503,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8522,8 +8524,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "clap",
  "eyre",
@@ -8544,8 +8546,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8560,8 +8562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8578,8 +8580,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8591,8 +8593,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8620,8 +8622,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8640,8 +8642,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8650,8 +8652,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8674,8 +8676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8695,8 +8697,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8708,8 +8710,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8726,8 +8728,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8764,8 +8766,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8778,8 +8780,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "serde",
  "serde_json",
@@ -8788,8 +8790,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8808,16 +8810,16 @@ dependencies = [
  "reth-tracing",
  "reth-trie",
  "revm",
- "revm-bytecode",
- "revm-database",
+ "revm-bytecode 8.0.0",
+ "revm-database 10.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-ipc"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "bytes",
  "futures",
@@ -8836,8 +8838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8852,8 +8854,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8861,8 +8863,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "futures",
  "metrics",
@@ -8873,8 +8875,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8882,8 +8884,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -8896,8 +8898,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8952,8 +8954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,8 +8979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,8 +9001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9014,8 +9016,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -9028,8 +9030,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "anyhow",
  "bincode",
@@ -9045,8 +9047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -9069,8 +9071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9128,6 +9130,7 @@ dependencies = [
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -9137,8 +9140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9193,8 +9196,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -9231,8 +9234,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9255,8 +9258,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,8 +9282,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "bytes",
  "eyre",
@@ -9303,8 +9306,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9315,8 +9318,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9343,8 +9346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9391,8 +9394,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9416,8 +9419,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9444,8 +9447,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9481,8 +9484,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -9492,8 +9495,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9538,8 +9541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9578,8 +9581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9593,8 +9596,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9654,8 +9657,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "reth-optimism-primitives",
@@ -9664,8 +9667,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9700,8 +9703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9721,8 +9724,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9733,8 +9736,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9756,8 +9759,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,8 +9769,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9776,8 +9779,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9790,8 +9793,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9812,9 +9815,9 @@ dependencies = [
  "proptest-arbitrary-interop",
  "rayon",
  "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "secp256k1 0.30.0",
  "serde",
  "serde_with",
@@ -9823,8 +9826,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9857,8 +9860,8 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie",
  "reth-trie-db",
- "revm-database",
- "revm-state",
+ "revm-database 10.0.0",
+ "revm-state 9.0.0",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -9866,8 +9869,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9894,8 +9897,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9909,8 +9912,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-protocol"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9928,8 +9931,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ress-provider"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9955,8 +9958,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9968,8 +9971,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10036,7 +10039,7 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "serde",
  "serde_json",
  "sha2",
@@ -10050,8 +10053,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -10075,14 +10078,13 @@ dependencies = [
  "reth-network-peers",
  "reth-rpc-eth-api",
  "reth-trie-common",
- "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10122,8 +10124,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10148,8 +10150,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10178,8 +10180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10222,8 +10224,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10270,8 +10272,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10284,8 +10286,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10300,8 +10302,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10345,8 +10347,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10372,8 +10374,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10386,8 +10388,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10406,8 +10408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10419,8 +10421,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10437,14 +10439,14 @@ dependencies = [
  "reth-stages-types",
  "reth-storage-errors",
  "reth-trie-common",
- "revm-database",
+ "revm-database 10.0.0",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10453,14 +10455,15 @@ dependencies = [
  "reth-primitives-traits",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
+ "revm-database-interface 9.0.0",
+ "revm-state 9.0.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tasks"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -10477,8 +10480,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10493,8 +10496,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10503,8 +10506,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "clap",
  "eyre",
@@ -10520,8 +10523,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "clap",
  "eyre",
@@ -10538,8 +10541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10564,7 +10567,7 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "revm-interpreter",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "rustc-hash",
  "schnellru",
  "serde",
@@ -10578,8 +10581,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10597,15 +10600,15 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-database",
+ "revm-database 10.0.0",
  "tracing",
  "triehash",
 ]
 
 [[package]]
 name = "reth-trie-common"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10624,30 +10627,35 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "reth-primitives-traits",
- "revm-database",
+ "revm-database 10.0.0",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-trie-db"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
+ "metrics",
+ "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-primitives-traits",
+ "reth-stages-types",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie",
+ "reth-trie-common",
  "tracing",
 ]
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10671,8 +10679,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10690,8 +10698,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10708,29 +10716,29 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.10.0"
-source = "git+https://github.com/okx/reth?rev=1ae6a8b15fe9bcaffbe730040118762f7a676f13#1ae6a8b15fe9bcaffbe730040118762f7a676f13"
+version = "1.10.2"
+source = "git+https://github.com/okx/reth?rev=61fd0a7229d9e0206478df3a841c3dd55bcc1080#61fd0a7229d9e0206478df3a841c3dd55bcc1080"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "33.1.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
+checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
+ "revm-context-interface 14.0.0",
+ "revm-database 10.0.0",
+ "revm-database-interface 9.0.0",
  "revm-handler",
  "revm-inspector",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
 ]
 
 [[package]]
@@ -10740,25 +10748,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
 dependencies = [
  "bitvec",
+ "revm-primitives 21.0.2",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+dependencies = [
+ "bitvec",
  "phf",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "12.1.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
+checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10772,9 +10790,24 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10784,11 +10817,23 @@ version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
+ "revm-bytecode 7.1.1",
+ "revm-database-interface 8.0.5",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+]
+
+[[package]]
+name = "revm-database"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+dependencies = [
  "alloy-eips",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0",
+ "revm-database-interface 9.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
@@ -10800,53 +10845,66 @@ checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 21.0.2",
+ "revm-state 8.1.1",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
+checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 8.0.0",
  "revm-context",
- "revm-context-interface",
- "revm-database-interface",
+ "revm-context-interface 14.0.0",
+ "revm-database-interface 9.0.0",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-inspector"
-version = "14.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
+checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
 dependencies = [
  "auto_impl",
  "either",
  "revm-context",
- "revm-database-interface",
+ "revm-database-interface 9.0.0",
  "revm-handler",
  "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-inspectors"
-version = "0.33.2"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01def7351cd9af844150b8e88980bcd11304f33ce23c3d7c25f2a8dab87c1345"
+checksum = "a24ca988ae1f7a0bb5688630579c00e867cd9f1df0a2f040623887f63d3b414c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10864,22 +10922,22 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "31.1.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
+checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
 dependencies = [
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 8.0.0",
+ "revm-context-interface 14.0.0",
+ "revm-primitives 22.0.0",
+ "revm-state 9.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a62958af953cc4043e93b5be9b8497df84cc3bd612b865c49a7a7dfa26a84e2"
+checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -10893,9 +10951,8 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-primitives",
+ "revm-primitives 22.0.0",
  "ripemd",
- "rug",
  "secp256k1 0.31.1",
  "sha2",
 ]
@@ -10905,6 +10962,17 @@ name = "revm-primitives"
 version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -10919,8 +10987,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
  "bitflags 2.10.0",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 7.1.1",
+ "revm-primitives 21.0.2",
+]
+
+[[package]]
+name = "revm-state"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.10.0",
+ "revm-bytecode 8.0.0",
+ "revm-primitives 22.0.0",
  "serde",
 ]
 
@@ -11072,18 +11152,6 @@ dependencies = [
  "nix 0.26.4",
  "thiserror 1.0.69",
  "tokio",
-]
-
-[[package]]
-name = "rug"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
 ]
 
 [[package]]
@@ -11699,9 +11767,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -11792,9 +11860,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skeptic"
@@ -11877,9 +11945,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -12025,9 +12093,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f92d01b5de07eaf324f7fca61cc6bd3d82bbc1de5b6c963e6fe79e86f36580d"
+checksum = "e629391be459480417646f7ca78894442249262a6e095dbd6e4ab6988cfafce0"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -12268,9 +12336,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -12286,15 +12354,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -12347,7 +12415,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -12706,9 +12774,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
+checksum = "9b567204f58bb0258b9bfe141193d7dd6c649033712eb01b8f3ceafff89c80a3"
 dependencies = [
  "time",
  "tracing",
@@ -13017,9 +13085,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -13042,12 +13110,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.0.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.23.1",
  "derive_builder",
  "regex",
  "rustversion",
@@ -13057,9 +13125,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "1.0.7"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -13072,9 +13140,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "0.1.6"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -14002,8 +14070,8 @@ dependencies = [
  "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "revm-context-interface",
- "revm-database",
+ "revm-context-interface 13.1.0",
+ "revm-database 9.0.6",
  "serde",
  "serde_json",
  "tokio",
@@ -14278,18 +14346,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "fdea86ddd5568519879b8187e1cf04e24fce28f7fe046ceecbce472ff19a2572"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14373,9 +14441,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,54 +74,54 @@ xlayer-trace-monitor = { git = "https://github.com/okx/xlayer-toolkit", rev = "0
 # ==============================================================================
 # Reth Dependencies (points to our fork)
 # ==============================================================================
-reth = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-chain-state = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-cli-commands = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-cli-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-db = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-db-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-engine-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-errors = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-ethereum-forks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-exex = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-execution-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-core = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-node = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-builder-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-provider = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-revm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-convert = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-engine-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-eth-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-storage-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-tasks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-tokio-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-tracing = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-flashblocks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-server-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-chain-state = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-chainspec = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-cli = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-cli-commands = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-cli-util = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-db = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-db-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-engine-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-errors = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-ethereum-forks = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-evm = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-exex = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-execution-types = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-core = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-types = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-node = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-payload-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-builder-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-provider = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-revm = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-convert = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-engine-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-eth-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-storage-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-tasks = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-tokio-util = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-tracing = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-flashblocks = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-server-types = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
 
 # ==============================================================================
 # Revm Dependencies (follows upstream reth)
@@ -136,7 +136,7 @@ revm-inspectors = { version = "0.33.2", default-features = false, features = [
 # ============================================================================== 
 # Flashblocks Dependencies
 # ============================================================================== 
-op-rbuilder = { git = "https://github.com/okx/op-rbuilder", tag = "v0.2.5" }
+op-rbuilder = { git = "https://github.com/okx/op-rbuilder", tag = "v0.3.0" }
 
 # ==============================================================================
 # Alloy Dependencies
@@ -144,25 +144,25 @@ op-rbuilder = { git = "https://github.com/okx/op-rbuilder", tag = "v0.2.5" }
 alloy-chains = { version = "0.2.20", default-features = false }
 alloy-consensus = { version = "1.4.3" }
 alloy-eips = { version = "1.4.3", default-features = false }
-alloy-evm = { version = "0.25.1", default-features = false }
+alloy-evm = { version = "0.26.3", default-features = false }
 alloy-genesis = { version = "1.4.3", default-features = false }
-alloy-json-rpc = { version = "1.1.0" }
-alloy-network = { version = "1.1.0", default-features = false }
-alloy-primitives = { version = "1.4.1", default-features = false, features = [
+alloy-json-rpc = { version = "1.4.3" }
+alloy-network = { version = "1.4.3", default-features = false }
+alloy-primitives = { version = "1.5.2", default-features = false, features = [
     "map-foldhash",
 ] }
 alloy-provider = { version = "1.4.3" }
 alloy-rlp = { version = "0.3.10", default-features = false, features = [
     "core-net",
 ] }
-alloy-rpc-client = { version = "1.1.0" }
+alloy-rpc-client = { version = "1.4.3" }
 alloy-rpc-types-engine = { version = "1.4.3", default-features = false }
 alloy-rpc-types-eth = { version = "1.4.3" }
 alloy-rpc-types-trace = { version = "1.4.3" }
-alloy-signer = { version = "1.1.0", default-features = false }
-alloy-signer-local = { version = "1.1.0", default-features = false }
-alloy-sol-types = { version = "1.4.1", default-features = false }
-alloy-transport-http = { version = "1.1.0" }
+alloy-signer = { version = "1.4.3", default-features = false }
+alloy-signer-local = { version = "1.4.3", default-features = false }
+alloy-sol-types = { version = "1.5.0", default-features = false }
+alloy-transport-http = { version = "1.4.3" }
 
 # op-alloy
 op-alloy-consensus = { version = "0.23.1", default-features = false }
@@ -213,55 +213,55 @@ moka = { version = "0.12.11", features = ["sync"] }
 # ==============================================================================
 # Redirects all paradigmxyz/reth dependencies to okx/reth fork for op-rbuilder.
 [patch."https://github.com/paradigmxyz/reth"]
-reth = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-basic-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-chain-state = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-cli-commands = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-cli-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-db = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-db-common = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-errors = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-evm-ethereum = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-exex = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-execution-errors = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-execution-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-ipc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-metrics = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-network-peers = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-core = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-node-ethereum = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-node = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-builder = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-builder-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-payload-util = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-primitives = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-provider = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-revm = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-engine-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-rpc-layer = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-storage-api = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-tasks = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-testing-utils = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-tracing-otlp = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-trie = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-trie-db = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
-reth-trie-parallel = { git = "https://github.com/okx/reth", rev = "1ae6a8b15fe9bcaffbe730040118762f7a676f13" }
+reth = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-basic-payload-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-chain-state = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-chainspec = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-cli = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-cli-commands = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-cli-util = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-db = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-db-common = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-errors = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-evm = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-evm-ethereum = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-exex = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-execution-errors = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-execution-types = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-ipc = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-metrics = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-network-peers = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-core = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-node-ethereum = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-chainspec = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-cli = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-consensus = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-evm = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-forks = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-node = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-payload-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-rpc = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-optimism-txpool = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-builder = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-builder-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-payload-util = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-primitives = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-primitives-traits = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-provider = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-revm = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-engine-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-rpc-layer = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-storage-api = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-tasks = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-testing-utils = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-tracing-otlp = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-transaction-pool = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-trie = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-trie-db = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }
+reth-trie-parallel = { git = "https://github.com/okx/reth", rev = "61fd0a7229d9e0206478df3a841c3dd55bcc1080" }

--- a/crates/version/Cargo.toml
+++ b/crates/version/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 reth-node-core.workspace = true
 
 [build-dependencies]
-vergen = { version = "=9.0.6", features = ["cargo", "emit_and_set"] }
-vergen-git2 = "1.0.7"
+vergen = { version = "9.1.0", features = ["cargo", "emit_and_set"] }
+vergen-git2 = "9.1.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

1. Upgrade Reth to version v1.10.2 based on okx/reth: https://github.com/okx/reth/commit/61fd0a7229d9e0206478df3a841c3dd55bcc1080
2. Upgrade op-rbuilder to release v0.3.0, based on reth v1.10.2 https://github.com/okx/op-rbuilder/releases/tag/v0.3.0