### PR TITLE
feat(rpc): use feeHistory over minGasPrice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14152,8 +14152,6 @@ dependencies = [
 name = "xlayer-rpc"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-primitives",
  "jsonrpsee",
  "reth-chainspec",
  "reth-optimism-rpc",
@@ -14162,7 +14160,6 @@ dependencies = [
  "reth-storage-api",
  "serde",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -17,12 +17,8 @@ reth-rpc.workspace = true
 reth-rpc-eth-api.workspace = true
 reth-storage-api.workspace = true
 
-alloy-consensus.workspace = true
-alloy-primitives.workspace = true
-
 jsonrpsee.workspace = true
 serde.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/rpc/src/xlayer_ext.rs
+++ b/crates/rpc/src/xlayer_ext.rs
@@ -1,13 +1,9 @@
 use std::sync::Arc;
 
-use alloy_consensus::BlockHeader;
-use alloy_primitives::U256;
 use jsonrpsee::{
     core::{async_trait, RpcResult},
     proc_macros::rpc,
-    types::error::INTERNAL_ERROR_CODE,
 };
-use tracing::{debug, warn};
 
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_optimism_rpc::SequencerClient;
@@ -37,12 +33,6 @@ pub trait PendingFlashBlockProvider {
         serde::de::DeserializeOwned + serde::Serialize
 ))]
 pub trait XlayerRpcExtApi<Net: RpcTypes> {
-    /// Returns the minimum gas price (base fee + default suggested fee).
-    ///
-    /// This is an XLayer-specific extension to the standard Ethereum RPC API.
-    #[method(name = "minGasPrice")]
-    async fn min_gas_price(&self) -> RpcResult<U256>;
-
     /// Returns boolean indicating if the node's flashblocks functionality is enabled and working.
     #[method(name = "flashblocksEnabled")]
     async fn flashblocks_enabled(&self) -> RpcResult<bool>;
@@ -72,53 +62,6 @@ where
         + HeaderProvider,
     Net: RpcTypes + Send + Sync + 'static,
 {
-    async fn min_gas_price(&self) -> RpcResult<U256> {
-        // Check if sequencer client is available (RPC node mode)
-        if let Some(sequencer) = self.backend.sequencer_client() {
-            match sequencer.request::<_, U256>("eth_minGasPrice", ()).await {
-                Ok(result) => {
-                    debug!(
-                        target: "rpc::xlayer",
-                        "Received eth_minGasPrice from sequencer: {result}"
-                    );
-                    return Ok(result);
-                }
-                Err(err) => {
-                    warn!(
-                        target: "rpc::xlayer",
-                        %err,
-                        "Failed to forward eth_minGasPrice to sequencer, falling back to local calculation"
-                    );
-                    // Fall through to local calculation
-                }
-            }
-        }
-
-        // Local calculation (sequencer mode or fallback)
-        let header = self.backend.provider().latest_header().map_err(|err| {
-            jsonrpsee::types::ErrorObjectOwned::owned(
-                INTERNAL_ERROR_CODE,
-                format!("Failed to get latest header: {err}"),
-                None::<()>,
-            )
-        })?;
-
-        let base_fee = header.and_then(|h| h.base_fee_per_gas()).unwrap_or_default();
-
-        // Get the default suggested fee from gas oracle config
-        let default_suggested_fee =
-            self.backend.gas_oracle().config().default_suggested_fee.unwrap_or_default();
-
-        let min_gas_price = U256::from(base_fee) + default_suggested_fee;
-
-        debug!(
-            target: "rpc::xlayer",
-            "Calculated min_gas_price locally: {min_gas_price}, base_fee: {base_fee}, default_suggested_fee: {default_suggested_fee}"
-        );
-
-        Ok(min_gas_price)
-    }
-
     async fn flashblocks_enabled(&self) -> RpcResult<bool> {
         Ok(self.backend.has_pending_flashblock())
     }
@@ -127,59 +70,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::PendingFlashBlockProvider;
-    use alloy_consensus::Header;
-    use alloy_primitives::U256;
     use std::time::{Duration, Instant};
     use tokio::sync::watch;
-
-    // Mock backend for testing
-    struct MockBackend {
-        base_fee: Option<u64>,
-        default_suggested_fee: Option<U256>,
-    }
-
-    impl MockBackend {
-        fn new(base_fee: Option<u64>, default_suggested_fee: Option<U256>) -> Self {
-            Self { base_fee, default_suggested_fee }
-        }
-
-        fn provider(&self) -> MockProvider {
-            MockProvider { base_fee: self.base_fee }
-        }
-
-        fn gas_oracle(&self) -> MockGasOracle {
-            MockGasOracle { default_suggested_fee: self.default_suggested_fee }
-        }
-    }
-
-    struct MockProvider {
-        base_fee: Option<u64>,
-    }
-
-    impl MockProvider {
-        fn latest_header(&self) -> Result<Option<Header>, String> {
-            if let Some(base_fee) = self.base_fee {
-                let header = Header { base_fee_per_gas: Some(base_fee), ..Header::default() };
-                Ok(Some(header))
-            } else {
-                Ok(None)
-            }
-        }
-    }
-
-    struct MockGasOracle {
-        default_suggested_fee: Option<U256>,
-    }
-
-    impl MockGasOracle {
-        fn config(&self) -> MockGasOracleConfig {
-            MockGasOracleConfig { default_suggested_fee: self.default_suggested_fee }
-        }
-    }
-
-    struct MockGasOracleConfig {
-        default_suggested_fee: Option<U256>,
-    }
 
     struct MockPendingFlashBlock {
         expires_at: Instant,
@@ -197,77 +89,6 @@ mod tests {
                 })
             })
         }
-    }
-
-    #[test]
-    fn test_min_gas_price_calculation() {
-        // Test case 1: Both base fee and default suggested fee are present
-        let backend = MockBackend::new(Some(1_000_000_000), Some(U256::from(500_000_000)));
-        let base_fee = backend.provider().latest_header().unwrap().unwrap().base_fee_per_gas;
-        let default_suggested_fee = backend.gas_oracle().config().default_suggested_fee;
-
-        let expected =
-            U256::from(base_fee.unwrap_or_default()) + default_suggested_fee.unwrap_or_default();
-        assert_eq!(expected, U256::from(1_500_000_000_u64));
-
-        // Test case 2: Only base fee is present
-        let backend = MockBackend::new(Some(2_000_000_000), None);
-        let base_fee = backend.provider().latest_header().unwrap().unwrap().base_fee_per_gas;
-        let default_suggested_fee = backend.gas_oracle().config().default_suggested_fee;
-
-        let expected =
-            U256::from(base_fee.unwrap_or_default()) + default_suggested_fee.unwrap_or_default();
-        assert_eq!(expected, U256::from(2_000_000_000_u64));
-
-        // Test case 3: Only default suggested fee is present
-        let backend = MockBackend::new(None, Some(U256::from(1_000_000_000)));
-        let header = backend.provider().latest_header().unwrap();
-        let base_fee = header.and_then(|h| h.base_fee_per_gas).unwrap_or_default();
-        let default_suggested_fee = backend.gas_oracle().config().default_suggested_fee;
-
-        let expected = U256::from(base_fee) + default_suggested_fee.unwrap_or_default();
-        assert_eq!(expected, U256::from(1_000_000_000_u64));
-
-        // Test case 4: Neither is present
-        let backend = MockBackend::new(None, None);
-        let header = backend.provider().latest_header().unwrap();
-        let base_fee = header.and_then(|h| h.base_fee_per_gas).unwrap_or_default();
-        let default_suggested_fee = backend.gas_oracle().config().default_suggested_fee;
-
-        let expected = U256::from(base_fee) + default_suggested_fee.unwrap_or_default();
-        assert_eq!(expected, U256::ZERO);
-    }
-
-    #[test]
-    fn test_min_gas_price_overflow_safety() {
-        // Test with maximum values to ensure no overflow
-        let backend = MockBackend::new(Some(u64::MAX), Some(U256::from(u64::MAX)));
-        let base_fee = backend.provider().latest_header().unwrap().unwrap().base_fee_per_gas;
-        let default_suggested_fee = backend.gas_oracle().config().default_suggested_fee;
-
-        let result =
-            U256::from(base_fee.unwrap_or_default()) + default_suggested_fee.unwrap_or_default();
-
-        // Should not panic and should produce a valid U256
-        assert!(result > U256::from(u64::MAX));
-    }
-
-    #[test]
-    fn test_min_gas_price_typical_values() {
-        // Test with typical mainnet values
-        // Base fee: 30 gwei, Suggested fee: 2 gwei
-        let base_fee_gwei = 30_000_000_000_u64; // 30 gwei in wei
-        let suggested_fee_gwei = U256::from(2_000_000_000_u64); // 2 gwei in wei
-
-        let backend = MockBackend::new(Some(base_fee_gwei), Some(suggested_fee_gwei));
-        let base_fee = backend.provider().latest_header().unwrap().unwrap().base_fee_per_gas;
-        let default_suggested_fee = backend.gas_oracle().config().default_suggested_fee;
-
-        let result =
-            U256::from(base_fee.unwrap_or_default()) + default_suggested_fee.unwrap_or_default();
-
-        // Expected: 32 gwei
-        assert_eq!(result, U256::from(32_000_000_000_u64));
     }
 
     #[test]


### PR DESCRIPTION
Recommended wallet guys to use `eth_feeHistory` over `minGasPrice`.