### PR TITLE
fix: macros compile err due to feat not active

### DIFF
--- a/crates/builder/src/tests/framework/macros/Cargo.toml
+++ b/crates/builder/src/tests/framework/macros/Cargo.toml
@@ -8,7 +8,7 @@ description = "Macros supporting the tests infrastructure for op-rbuilder"
 proc-macro = true
 
 [dependencies]
-syn = "2.0"
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 paste = "1.0"


### PR DESCRIPTION
After: `just sc` all pass.

<img width="2818" height="736" alt="image" src="https://github.com/user-attachments/assets/845030c5-1f96-4918-b3e4-0d5e16cb12de" />
