### PR TITLE
refactor(builder): remove unnecessary clones in flashblocks payload builder

### DIFF
--- a/crates/builder/src/builders/flashblocks/payload.rs
+++ b/crates/builder/src/builders/flashblocks/payload.rs
@@ -628,7 +628,7 @@ where
             gas_used = info.cumulative_gas_used,
             target_da = target_da_for_batch,
             da_used = info.cumulative_da_bytes_used,
-            block_gas_used = ctx.block_gas_limit(),
+            block_gas_limit = ctx.block_gas_limit(),
             target_da_footprint = target_da_footprint_for_batch,
             "Building flashblock",
         );


### PR DESCRIPTION
## Summary

- Based on the upstream PR: https://github.com/flashbots/op-rbuilder/commit/1d701d26b0e81d08ee82af5daf6d5d0b2a4257bc#diff-20125ce86c70cfd520b09bc61e2032873f80249afe0027ee76dfbfcb503e7fb7R998
- Refactors the builder logic by removing unnecessary clones of the execution outcome and bundled states