### PR TITLE
build: speed up docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,13 @@ Dockerfile*
 *.md
 docs/
 
-# Tests
-tests/
+# Tests – exclude test sources but keep manifests/stubs needed by cargo
+crates/tests/e2e-tests/
+crates/tests/flashblocks-tests/
+crates/tests/operations/
+crates/builder/src/tests/
+!crates/builder/src/tests/framework/macros/Cargo.toml
+!crates/builder/src/tests/framework/macros/src/lib.rs
 
 # Build outputs
 dist/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 target/
 
 # Git
-.git/
+#.git/
 .gitignore
 
 # IDE & System
@@ -19,12 +19,8 @@ Dockerfile*
 docs/
 
 # Tests – exclude test sources but keep manifests/stubs needed by cargo
-crates/tests/e2e-tests/
-crates/tests/flashblocks-tests/
-crates/tests/operations/
-crates/builder/src/tests/
-!crates/builder/src/tests/framework/macros/Cargo.toml
-!crates/builder/src/tests/framework/macros/src/lib.rs
+crates/tests/
+tests/
 
 # Build outputs
 dist/

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 target/
 
 # Git
-#.git/
+.git/
 .gitignore
 
 # IDE & System
@@ -20,3 +20,8 @@ docs/
 
 # Tests
 tests/
+
+# Build outputs
+dist/
+tmp/
+node_modules/

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -13,16 +13,11 @@ COPY bin/node/Cargo.toml bin/node/Cargo.toml
 COPY bin/tools/Cargo.toml bin/tools/Cargo.toml
 COPY --parents crates/*/Cargo.toml ./
 COPY crates/builder/src/tests/framework/macros/Cargo.toml crates/builder/src/tests/framework/macros/Cargo.toml
-RUN find crates -name Cargo.toml -print0 | while IFS= read -r -d '' manifest; do \
-        dir=$(dirname "$manifest"); \
-        mkdir -p "$dir/src"; \
-        touch "$dir/src/lib.rs" "$dir/src/main.rs"; \
-    done
-RUN find bin -name Cargo.toml -print0 | while IFS= read -r -d '' manifest; do \
-        dir=$(dirname "$manifest"); \
-        mkdir -p "$dir/src"; \
-        touch "$dir/src/main.rs"; \
-    done
+COPY --parents crates/*/src/lib.rs ./
+COPY crates/tests/lib.rs crates/tests/lib.rs
+COPY crates/builder/src/tests/framework/macros/src/lib.rs crates/builder/src/tests/framework/macros/src/lib.rs
+COPY bin/node/src/main.rs bin/node/src/main.rs
+COPY bin/tools/main.rs bin/tools/main.rs
 RUN cargo chef prepare --recipe-path recipe.json --bin xlayer-reth-node
 
 FROM chef AS builder

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-
 # Builds a cargo-chef plan
 FROM chef AS planner
 COPY . .
+# Remove test-only workspace members that are excluded from the Docker context
+RUN sed -i '/"crates\/tests"/d' Cargo.toml
 RUN cargo chef prepare --recipe-path recipe.json --bin xlayer-reth-node
 
 FROM chef AS builder
@@ -35,6 +37,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml
 
 COPY . .
+# Remove test-only workspace members that are excluded from the Docker context
+RUN sed -i '/"crates\/tests"/d' Cargo.toml
 RUN if [ -d .cargo/reth ]; then \
         mv .cargo/reth /reth; \
     else \

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -13,6 +13,16 @@ COPY bin/node/Cargo.toml bin/node/Cargo.toml
 COPY bin/tools/Cargo.toml bin/tools/Cargo.toml
 COPY --parents crates/*/Cargo.toml ./
 COPY crates/builder/src/tests/framework/macros/Cargo.toml crates/builder/src/tests/framework/macros/Cargo.toml
+RUN find crates -name Cargo.toml -print0 | while IFS= read -r -d '' manifest; do \
+        dir=$(dirname "$manifest"); \
+        mkdir -p "$dir/src"; \
+        touch "$dir/src/lib.rs" "$dir/src/main.rs"; \
+    done
+RUN find bin -name Cargo.toml -print0 | while IFS= read -r -d '' manifest; do \
+        dir=$(dirname "$manifest"); \
+        mkdir -p "$dir/src"; \
+        touch "$dir/src/main.rs"; \
+    done
 RUN cargo chef prepare --recipe-path recipe.json --bin xlayer-reth-node
 
 FROM chef AS builder

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -49,7 +49,7 @@ RUN if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; f
 COPY . .
 RUN if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; fi && \
     if [ -n "$VERGEN_GIT_COMMIT_TIMESTAMP" ]; then export VERGEN_GIT_COMMIT_TIMESTAMP="$VERGEN_GIT_COMMIT_TIMESTAMP"; fi && \
-    cargo build --profile $BUILD_PROFILE --bin xlayer-reth-node --manifest-path /app/bin/node/Cargo.toml
+    cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin xlayer-reth-node --manifest-path /app/bin/node/Cargo.toml
 
 # Copy binary to a fixed location
 RUN OUTPUT_DIR=$(if [ "$BUILD_PROFILE" = "dev" ] || [ "$BUILD_PROFILE" = "test" ]; then echo debug; else echo "$BUILD_PROFILE"; fi) && \

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -6,28 +6,17 @@ LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 
-# Builds a cargo-chef plan
+# Builds a cargo-chef plan (manifest-only)
 FROM chef AS planner
-COPY . .
-# For dev builds: move .cargo/reth to /reth (same level as /app, not nested)
-# This avoids nested workspace issues. Create empty /reth if not dev mode.
-RUN if [ -d .cargo/reth ]; then \
-        mv .cargo/reth /reth; \
-    else \
-        mkdir -p /reth; \
-    fi
-# Temporarily disable .cargo/config.toml during cargo chef prepare
-# to avoid path conflicts (it will be restored and copied to builder stage)
-RUN if [ -f .cargo/config.toml ]; then mv .cargo/config.toml .cargo/config.toml.bak; fi
-RUN mkdir -p .cargo
-RUN cargo chef prepare --recipe-path recipe.json
-RUN if [ -f .cargo/config.toml.bak ]; then mv .cargo/config.toml.bak .cargo/config.toml; fi
+COPY Cargo.toml Cargo.lock rust-toolchain* ./
+COPY bin/node/Cargo.toml bin/node/Cargo.toml
+COPY bin/tools/Cargo.toml bin/tools/Cargo.toml
+COPY crates/*/Cargo.toml crates/*/Cargo.toml
+COPY crates/builder/src/tests/framework/macros/Cargo.toml crates/builder/src/tests/framework/macros/Cargo.toml
+RUN cargo chef prepare --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-COPY --from=planner /app/.cargo /app/.cargo
-# Copy /reth from planner (will be empty dir in prod mode, reth source in dev mode)
-COPY --from=planner /reth /reth
 
 ARG BUILD_PROFILE=release
 ENV BUILD_PROFILE=$BUILD_PROFILE
@@ -42,12 +31,23 @@ ENV FEATURES=$FEATURES
 ARG VERGEN_GIT_SHA
 ARG VERGEN_GIT_COMMIT_TIMESTAMP
 
-RUN if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; fi && \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; fi && \
     if [ -n "$VERGEN_GIT_COMMIT_TIMESTAMP" ]; then export VERGEN_GIT_COMMIT_TIMESTAMP="$VERGEN_GIT_COMMIT_TIMESTAMP"; fi && \
     cargo chef cook --profile $BUILD_PROFILE --features "$FEATURES" --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml
 
 COPY . .
-RUN if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; fi && \
+RUN if [ -d .cargo/reth ]; then \
+        mv .cargo/reth /reth; \
+    else \
+        mkdir -p /reth; \
+    fi
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; fi && \
     if [ -n "$VERGEN_GIT_COMMIT_TIMESTAMP" ]; then export VERGEN_GIT_COMMIT_TIMESTAMP="$VERGEN_GIT_COMMIT_TIMESTAMP"; fi && \
     cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin xlayer-reth-node --manifest-path /app/bin/node/Cargo.toml
 

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -11,9 +11,9 @@ FROM chef AS planner
 COPY Cargo.toml Cargo.lock rust-toolchain* ./
 COPY bin/node/Cargo.toml bin/node/Cargo.toml
 COPY bin/tools/Cargo.toml bin/tools/Cargo.toml
-COPY crates/*/Cargo.toml crates/*/Cargo.toml
+COPY --parents crates/*/Cargo.toml ./
 COPY crates/builder/src/tests/framework/macros/Cargo.toml crates/builder/src/tests/framework/macros/Cargo.toml
-RUN cargo chef prepare --recipe-path recipe.json --manifest-path /app/bin/node/Cargo.toml
+RUN cargo chef prepare --recipe-path recipe.json --bin xlayer-reth-node
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -6,18 +6,9 @@ LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"
 
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 
-# Builds a cargo-chef plan (manifest-only)
+# Builds a cargo-chef plan
 FROM chef AS planner
-COPY Cargo.toml Cargo.lock rust-toolchain* ./
-COPY bin/node/Cargo.toml bin/node/Cargo.toml
-COPY bin/tools/Cargo.toml bin/tools/Cargo.toml
-COPY --parents crates/*/Cargo.toml ./
-COPY crates/builder/src/tests/framework/macros/Cargo.toml crates/builder/src/tests/framework/macros/Cargo.toml
-COPY --parents crates/*/src/lib.rs ./
-COPY crates/tests/lib.rs crates/tests/lib.rs
-COPY crates/builder/src/tests/framework/macros/src/lib.rs crates/builder/src/tests/framework/macros/src/lib.rs
-COPY bin/node/src/main.rs bin/node/src/main.rs
-COPY bin/tools/main.rs bin/tools/main.rs
+COPY . .
 RUN cargo chef prepare --recipe-path recipe.json --bin xlayer-reth-node
 
 FROM chef AS builder

--- a/DockerfileOp
+++ b/DockerfileOp
@@ -54,10 +54,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     if [ -n "$VERGEN_GIT_SHA" ]; then export VERGEN_GIT_SHA="$VERGEN_GIT_SHA"; fi && \
     if [ -n "$VERGEN_GIT_COMMIT_TIMESTAMP" ]; then export VERGEN_GIT_COMMIT_TIMESTAMP="$VERGEN_GIT_COMMIT_TIMESTAMP"; fi && \
-    cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin xlayer-reth-node --manifest-path /app/bin/node/Cargo.toml
-
-# Copy binary to a fixed location
-RUN OUTPUT_DIR=$(if [ "$BUILD_PROFILE" = "dev" ] || [ "$BUILD_PROFILE" = "test" ]; then echo debug; else echo "$BUILD_PROFILE"; fi) && \
+    cargo build --profile $BUILD_PROFILE --features "$FEATURES" --bin xlayer-reth-node --manifest-path /app/bin/node/Cargo.toml && \
+    OUTPUT_DIR=$(if [ "$BUILD_PROFILE" = "dev" ] || [ "$BUILD_PROFILE" = "test" ]; then echo debug; else echo "$BUILD_PROFILE"; fi) && \
     cp /app/target/$OUTPUT_DIR/xlayer-reth-node /app/op-reth
 
 FROM ubuntu:24.04 AS runtime


### PR DESCRIPTION
## Summary
Overall ~48% reduction in build time. Ran builds multiple times to verify timings.

- stabilize cargo-chef planner with manifest-only context and minimal targets
- add BuildKit cache mounts for cargo registry/git/target in cook/build stages
- tighten .dockerignore to reduce context churn

## Testing
- time -p just build-docker (with/without improvements)

## Build timings
- Without changes: real 296s
- With optimizations: real 153s