### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/crates/builder/src/builders/flashblocks/builder_tx.rs
+++ b/crates/builder/src/builders/flashblocks/builder_tx.rs
@@ -7,7 +7,6 @@ use alloy_sol_types::{sol, SolCall, SolEvent};
 use core::fmt::Debug;
 use op_alloy_rpc_types::OpTransactionRequest;
 use reth_evm::{precompiles::PrecompilesMap, ConfigureEvm};
-use reth_provider::StateProvider;
 use reth_revm::State;
 use revm::{inspector::NoOpInspector, DatabaseRef};
 use tracing::warn;
@@ -20,7 +19,6 @@ use crate::{
         get_nonce, BuilderTransactionCtx, BuilderTransactionError, BuilderTransactions,
         SimulationSuccessResult,
     },
-    primitives::reth::ExecutionInfo,
     tx_signer::Signer,
 };
 

--- a/crates/builder/src/tests/data_availability.rs
+++ b/crates/builder/src/tests/data_availability.rs
@@ -151,8 +151,8 @@ async fn da_footprint_fills_to_limit(rbuilder: LocalInstance) -> eyre::Result<()
 
     // Verify the block fills up to the DA footprint limit
     // accounting for builder tx DA contribution
-    for i in 0..7 {
-        assert!(block.includes(&tx_hashes[i]), "tx {i} should be included in the block",);
+    for (i, tx_hash) in tx_hashes.iter().take(7).enumerate() {
+        assert!(block.includes(tx_hash), "tx {i} should be included in the block");
     }
 
     // Verify the last 2 txs don't fit due to DA footprint limit

--- a/crates/builder/src/tests/smoke.rs
+++ b/crates/builder/src/tests/smoke.rs
@@ -91,7 +91,7 @@ async fn chain_produces_blocks(rbuilder: LocalInstance) -> eyre::Result<()> {
 /// with other requests, such as fcu or getPayload.
 #[rb_test(multi_threaded)]
 async fn produces_blocks_under_load_within_deadline(rbuilder: LocalInstance) -> eyre::Result<()> {
-    let driver = rbuilder.driver().await?.with_gas_limit(10_00_000);
+    let driver = rbuilder.driver().await?.with_gas_limit(1_000_000);
 
     let done = AtomicBool::new(false);
 


### PR DESCRIPTION
## Summary
- remove unused imports in flashblocks builder tx
- align builder tests with clippy lint expectations