### PR TITLE
rpc: remove unnecessary trait bounds and dependencies from XlayerRpcExtApiServer impl

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -11,11 +11,9 @@ repository.workspace = true
 default = []
 
 [dependencies]
-reth-chainspec.workspace = true
 reth-optimism-rpc.workspace = true
 reth-rpc.workspace = true
 reth-rpc-eth-api.workspace = true
-reth-storage-api.workspace = true
 
 jsonrpsee.workspace = true
 serde.workspace = true

--- a/crates/rpc/src/xlayer_ext.rs
+++ b/crates/rpc/src/xlayer_ext.rs
@@ -5,14 +5,8 @@ use jsonrpsee::{
     proc_macros::rpc,
 };
 
-use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_optimism_rpc::SequencerClient;
 use reth_rpc::RpcTypes;
-use reth_rpc_eth_api::{
-    helpers::{EthFees, LoadBlock, LoadFee},
-    EthApiTypes,
-};
-use reth_storage_api::{BlockReaderIdExt, HeaderProvider, ProviderHeader};
 
 /// Trait for accessing sequencer client from backend
 pub trait SequencerClientProvider {
@@ -47,19 +41,7 @@ pub struct XlayerRpcExt<T> {
 #[async_trait]
 impl<T, Net> XlayerRpcExtApiServer<Net> for XlayerRpcExt<T>
 where
-    T: EthFees
-        + LoadFee
-        + LoadBlock
-        + EthApiTypes<NetworkTypes = Net>
-        + SequencerClientProvider
-        + PendingFlashBlockProvider
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    T::Provider: ChainSpecProvider<ChainSpec: EthChainSpec<Header = ProviderHeader<T::Provider>>>
-        + BlockReaderIdExt
-        + HeaderProvider,
+    T: PendingFlashBlockProvider + Send + Sync + 'static,
     Net: RpcTypes + Send + Sync + 'static,
 {
     async fn flashblocks_enabled(&self) -> RpcResult<bool> {


### PR DESCRIPTION
## Description

The `XlayerRpcExtApiServer` impl for `XlayerRpcExt<T>` had excessive trait bounds that were never actually used. The only method (`flashblocks_enabled`) calls `self.backend.has_pending_flashblock()`, which only requires `PendingFlashBlockProvider`. This PR strips the unused bounds and their corresponding imports/dependencies.

**Removed trait bounds on `T`:** `EthFees`, `LoadFee`, `LoadBlock`, `EthApiTypes<NetworkTypes = Net>`, `SequencerClientProvider`, `Clone`, and the entire `T::Provider: ChainSpecProvider<...> + BlockReaderIdExt + HeaderProvider` clause.

**Removed unused crate dependencies:** `reth-chainspec`, `reth-storage-api`.

**Kept:** `PendingFlashBlockProvider + Send + Sync + 'static` (the only bounds actually needed).

This reduces compile-time trait resolution work and shrinks the dependency graph for the `xlayer-rpc` crate.

## Type of Change
- [x] Refactoring (no functional changes)

## Checklist
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

## Testing

- `cargo check -p xlayer-rpc` — passes
- `cargo test -p xlayer-rpc` — all 4 existing tests pass

## Human Review Checklist

- [ ] **Verify full workspace build**: The downstream binary (`bin/node/src/main.rs`) instantiates `XlayerRpcExt` with `Arc<OpEthApi<...>>`. Confirm it compiles with the reduced bounds (local build hit an unrelated `openssl-sys` system dep issue before reaching that crate).
- [ ] **Confirm no implicit bound requirements from jsonrpsee codegen**: The `#[rpc]` macro generates `into_rpc()` — verify it doesn't silently depend on any removed bounds at the call site in `main.rs`.

## Additional Notes

Link to Devin session: https://app.devin.ai/sessions/12a9c90470fa4e81a5441eb476edce91
Requested by: @Vui-Chee