### PR TITLE
feat(tools): add legacy data migration subcommand

### DIFF
--- a/.reth-dev.toml
+++ b/.reth-dev.toml
@@ -50,6 +50,8 @@ reth-rpc-eth-api = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-eth-api" }
 reth-rpc-eth-types = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-eth-types" }
 reth-rpc-layer = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-server-types" }
+reth-stages = { path = "RETH_PATH_PLACEHOLDER/crates/stages/stages" }
+reth-static-file-types = { path = "RETH_PATH_PLACEHOLDER/crates/static-file/types" }
 reth-storage-api = { path = "RETH_PATH_PLACEHOLDER/crates/storage/storage-api" }
 reth-tasks = { path = "RETH_PATH_PLACEHOLDER/crates/tasks" }
 reth-testing-utils = { path = "RETH_PATH_PLACEHOLDER/testing/testing-utils" }
@@ -105,6 +107,8 @@ reth-rpc-api = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-api" }
 reth-rpc-engine-api = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-engine-api" }
 reth-rpc-eth-types = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-eth-types" }
 reth-rpc-layer = { path = "RETH_PATH_PLACEHOLDER/crates/rpc/rpc-layer" }
+reth-stages = { path = "RETH_PATH_PLACEHOLDER/crates/stages/stages" }
+reth-static-file-types = { path = "RETH_PATH_PLACEHOLDER/crates/static-file/types" }
 reth-storage-api = { path = "RETH_PATH_PLACEHOLDER/crates/storage/storage-api" }
 reth-tasks = { path = "RETH_PATH_PLACEHOLDER/crates/tasks" }
 reth-testing-utils = { path = "RETH_PATH_PLACEHOLDER/testing/testing-utils" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,6 +5660,22 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen 0.72.1",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "tikv-jemalloc-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -9902,6 +9928,7 @@ dependencies = [
  "reth-trie-db",
  "revm-database",
  "revm-state",
+ "rocksdb",
  "strum 0.27.2",
  "tokio",
  "tracing",
@@ -11072,6 +11099,16 @@ checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -14326,14 +14363,19 @@ dependencies = [
  "reth-cli",
  "reth-cli-commands",
  "reth-cli-util",
+ "reth-db",
  "reth-db-api",
+ "reth-node-builder",
  "reth-node-core",
  "reth-node-types",
  "reth-optimism-chainspec",
  "reth-optimism-consensus",
  "reth-optimism-evm",
  "reth-optimism-node",
+ "reth-primitives-traits",
  "reth-provider",
+ "reth-stages",
+ "reth-static-file-types",
  "reth-storage-api",
  "reth-tracing",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,8 @@ reth-rpc-eth-api = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abd
 reth-rpc-eth-types = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
 reth-rpc-layer = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
 reth-rpc-server-types = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
+reth-stages = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
+reth-static-file-types = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
 reth-storage-api = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
 reth-tasks = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }
 reth-testing-utils = { git = "https://github.com/okx/reth", rev = "b6a31f31af91abdecb475f2a991906bff9bbef7f" }

--- a/bin/tools/Cargo.toml
+++ b/bin/tools/Cargo.toml
@@ -32,9 +32,14 @@ reth-tracing.workspace = true
 reth-node-core.workspace = true
 reth-node-types.workspace = true
 reth-chainspec.workspace = true
-reth-provider.workspace = true
+reth-provider = { workspace = true, features = ["rocksdb"] }
+reth-stages = { workspace = true, features = ["rocksdb"] }
 reth-storage-api.workspace = true
 reth-db-api.workspace = true
+reth-db.workspace = true
+reth-node-builder.workspace = true
+reth-primitives-traits.workspace = true
+reth-static-file-types.workspace = true
 
 # alloy
 alloy-consensus.workspace = true

--- a/bin/tools/main.rs
+++ b/bin/tools/main.rs
@@ -13,9 +13,13 @@ use xlayer_chainspec::XLayerChainSpecParser;
 mod export;
 mod gen_genesis;
 mod import;
+mod migrate;
+mod migrate_command;
+mod progress;
 use export::ExportCommand;
 use gen_genesis::GenGenesisCommand;
 use import::ImportCommand;
+use migrate_command::MigrateCommand;
 
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
@@ -37,6 +41,8 @@ enum Commands {
     Export(ExportCommand<XLayerChainSpecParser>),
     /// Generate a genesis file from an existing database
     GenGenesis(GenGenesisCommand<XLayerChainSpecParser>),
+    /// Migrate from legacy MDBX storage to new RocksDB + static files
+    Migrate(MigrateCommand<XLayerChainSpecParser>),
 }
 
 #[tokio::main]
@@ -92,6 +98,17 @@ async fn main() -> ExitCode {
                 Ok(_) => ExitCode::SUCCESS,
                 Err(e) => {
                     error!(target: "xlayer::gen_genesis", "Error: {:#?}", e);
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        Commands::Migrate(cmd) => {
+            info!(target: "xlayer::migrate", "XLayer Legacy Data Migration starting");
+
+            match cmd.execute::<OpNode>().await {
+                Ok(_) => ExitCode::SUCCESS,
+                Err(e) => {
+                    error!(target: "xlayer::migrate", "Error: {:#?}", e);
                     ExitCode::FAILURE
                 }
             }

--- a/bin/tools/migrate.rs
+++ b/bin/tools/migrate.rs
@@ -1,0 +1,318 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use alloy_primitives::BlockNumber;
+use eyre::Result;
+use rayon::prelude::*;
+use tracing::info;
+
+use crate::progress::{log_progress, log_rocksdb_progress, PROGRESS_LOG_INTERVAL};
+use reth_cli_commands::common::CliNodeTypes;
+use reth_db::{cursor::DbCursorRO, tables, transaction::DbTx, DatabaseEnv};
+use reth_db_api::models::AccountBeforeTx;
+use reth_node_builder::NodeTypesWithDBAdapter;
+use reth_provider::{
+    BlockBodyIndicesProvider, DBProvider, ProviderFactory, StaticFileProviderFactory,
+    StaticFileWriter, TransactionsProvider,
+};
+use reth_static_file_types::StaticFileSegment;
+
+pub(crate) fn migrate_to_static_files<N: CliNodeTypes>(
+    provider_factory: &ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+    genesis_block: BlockNumber,
+    to_block: BlockNumber,
+    can_migrate_receipts: bool,
+) -> Result<()> {
+    let mut segments = vec![
+        StaticFileSegment::TransactionSenders,
+        StaticFileSegment::AccountChangeSets,
+    ];
+    if can_migrate_receipts {
+        segments.push(StaticFileSegment::Receipts);
+    }
+
+    segments.into_par_iter().try_for_each(|segment| {
+        migrate_segment::<N>(provider_factory, segment, genesis_block, to_block)
+    })?;
+
+    Ok(())
+}
+
+pub(crate) fn migrate_segment<N: CliNodeTypes>(
+    provider_factory: &ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+    segment: StaticFileSegment,
+    genesis_block: BlockNumber,
+    to_block: BlockNumber,
+) -> Result<()> {
+    let static_file_provider = provider_factory.static_file_provider();
+
+    let provider = provider_factory.provider()?.disable_long_read_transaction_safety();
+
+    let highest = static_file_provider.get_highest_static_file_block(segment).unwrap_or(0);
+
+    // Calculate start block, ensuring it's >= genesis
+    let start = std::cmp::max(highest.saturating_add(1), genesis_block);
+
+    // Check if already up to date or start is beyond end
+    if start > to_block {
+        info!(target: "reth::cli", ?segment, highest, genesis_block, to_block, "Already up to date or beyond range");
+        return Ok(());
+    }
+
+    let total_blocks = to_block.saturating_sub(start) + 1;
+    info!(target: "reth::cli", ?segment, from = start, to = to_block, total_blocks, "Migrating");
+
+    // Get writer for the segment, starting at genesis block if it's empty
+    let mut writer = if highest == 0 && genesis_block > 0 {
+        info!(target: "reth::cli", ?segment, "Initializing static file with genesis block");
+        // get_writer(genesis_block, segment) will create a new file starting at genesis_block
+        static_file_provider.get_writer(genesis_block, segment)?
+    } else {
+        info!(target: "reth::cli", ?segment, "Continuing static file from block {}", highest + 1);
+        static_file_provider.latest_writer(segment)?
+    };
+
+    let segment_start = Instant::now();
+    let mut last_log = Instant::now();
+    let mut blocks_processed = 0u64;
+    let mut entries_processed = 0u64;
+
+    match segment {
+        StaticFileSegment::TransactionSenders => {
+            for block in start..=to_block {
+                if let Some(body) = provider.block_body_indices(block)? {
+                    let senders = provider.senders_by_tx_range(
+                        body.first_tx_num..body.first_tx_num + body.tx_count,
+                    )?;
+                    for (i, sender) in senders.into_iter().enumerate() {
+                        writer.append_transaction_sender(body.first_tx_num + i as u64, &sender)?;
+                        entries_processed += 1;
+                    }
+                }
+                blocks_processed += 1;
+                if last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                    log_progress(
+                        segment,
+                        blocks_processed,
+                        total_blocks,
+                        entries_processed,
+                        segment_start.elapsed(),
+                    );
+                    last_log = Instant::now();
+                }
+            }
+        }
+
+        StaticFileSegment::AccountChangeSets => {
+            let tx = provider.tx_ref();
+            let mut cursor = tx.cursor_dup_read::<tables::AccountChangeSets>()?;
+
+            let mut current_block = start;
+            let mut block_changesets: Vec<AccountBeforeTx> = Vec::new();
+
+            for result in cursor.walk_range(start..=to_block)? {
+                let (block, changeset): (BlockNumber, AccountBeforeTx) = result?;
+
+                if block != current_block {
+                    if !block_changesets.is_empty() {
+                        writer.append_account_changeset(
+                            std::mem::take(&mut block_changesets),
+                            current_block,
+                        )?;
+                    }
+                    if writer.current_block_number().is_some() {
+                        writer.ensure_at_block(block.saturating_sub(1))?;
+                    }
+                    blocks_processed += block - current_block;
+                    current_block = block;
+
+                    if last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                        log_progress(
+                            segment,
+                            blocks_processed,
+                            total_blocks,
+                            entries_processed,
+                            segment_start.elapsed(),
+                        );
+                        last_log = Instant::now();
+                    }
+                }
+                block_changesets.push(changeset);
+                entries_processed += 1;
+            }
+
+            if !block_changesets.is_empty() {
+                writer.append_account_changeset(block_changesets, current_block)?;
+            }
+        }
+
+        StaticFileSegment::Receipts => {
+            let tx = provider.tx_ref();
+            let mut cursor = tx.cursor_read::<tables::Receipts<_>>()?;
+            for block in start..=to_block {
+                if let Some(body) = provider.block_body_indices(block)? {
+                    for tx_num in body.first_tx_num..body.first_tx_num + body.tx_count {
+                        if let Some(receipt) = cursor.seek_exact(tx_num)?.map(|(_, r)| r) {
+                            writer.append_receipt(tx_num, &receipt)?;
+                            entries_processed += 1;
+                        }
+                    }
+                }
+                blocks_processed += 1;
+                if last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                    log_progress(
+                        segment,
+                        blocks_processed,
+                        total_blocks,
+                        entries_processed,
+                        segment_start.elapsed(),
+                    );
+                    last_log = Instant::now();
+                }
+            }
+        }
+
+        _ => (),
+    }
+
+    writer.commit()?;
+
+    let elapsed = segment_start.elapsed();
+    let rate = if elapsed.as_secs() > 0 {
+        entries_processed / elapsed.as_secs()
+    } else {
+        entries_processed
+    };
+    info!(
+        target: "reth::cli",
+        ?segment,
+        entries = entries_processed,
+        elapsed_secs = elapsed.as_secs(),
+        rate_per_sec = rate,
+        "Done"
+    );
+
+    Ok(())
+}
+
+pub(crate) fn migrate_to_rocksdb<N: CliNodeTypes>(
+    provider_factory: &ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+    batch_size: u64,
+) -> Result<()> {
+    use reth_db_api::table::Table;
+
+    [
+        tables::TransactionHashNumbers::NAME,
+        tables::AccountsHistory::NAME,
+        tables::StoragesHistory::NAME,
+    ]
+    .into_par_iter()
+    .try_for_each(|table| migrate_rocksdb_table::<N>(provider_factory, table, batch_size))?;
+
+    Ok(())
+}
+
+pub(crate) fn migrate_rocksdb_table<N: CliNodeTypes>(
+    provider_factory: &ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+    table: &'static str,
+    batch_size: u64,
+) -> Result<()> {
+    use reth_db_api::table::Table;
+    use reth_provider::RocksDBProviderFactory;
+
+    let provider = provider_factory.provider()?.disable_long_read_transaction_safety();
+    let rocksdb = provider_factory.rocksdb_provider();
+    let tx = provider.tx_ref();
+
+    info!(target: "reth::cli", table, "Migrating");
+
+    let table_start = Instant::now();
+    let mut last_log = Instant::now();
+
+    let count = match table {
+        tables::TransactionHashNumbers::NAME => {
+            let mut cursor = tx.cursor_read::<tables::TransactionHashNumbers>()?;
+            let mut batch = rocksdb.batch();
+            let mut count = 0u64;
+
+            for result in cursor.walk(None)? {
+                let (hash, tx_num) = result?;
+                batch.put::<tables::TransactionHashNumbers>(hash, &tx_num)?;
+                count += 1;
+
+                if count.is_multiple_of(batch_size) {
+                    batch.commit()?;
+                    batch = rocksdb.batch();
+
+                    if last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                        log_rocksdb_progress(table, count, table_start.elapsed());
+                        last_log = Instant::now();
+                    }
+                }
+            }
+
+            batch.commit()?;
+            count
+        }
+        tables::AccountsHistory::NAME => {
+            let mut cursor = tx.cursor_read::<tables::AccountsHistory>()?;
+            let mut batch = rocksdb.batch();
+            let mut count = 0u64;
+
+            for result in cursor.walk(None)? {
+                let (key, value) = result?;
+                batch.put::<tables::AccountsHistory>(key, &value)?;
+                count += 1;
+                if count.is_multiple_of(batch_size) {
+                    batch.commit()?;
+                    batch = rocksdb.batch();
+
+                    if last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                        log_rocksdb_progress(table, count, table_start.elapsed());
+                        last_log = Instant::now();
+                    }
+                }
+            }
+
+            batch.commit()?;
+            count
+        }
+        tables::StoragesHistory::NAME => {
+            let mut cursor = tx.cursor_read::<tables::StoragesHistory>()?;
+            let mut batch = rocksdb.batch();
+            let mut count = 0u64;
+
+            for result in cursor.walk(None)? {
+                let (key, value) = result?;
+                batch.put::<tables::StoragesHistory>(key, &value)?;
+                count += 1;
+                if count.is_multiple_of(batch_size) {
+                    batch.commit()?;
+                    batch = rocksdb.batch();
+
+                    if last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                        log_rocksdb_progress(table, count, table_start.elapsed());
+                        last_log = Instant::now();
+                    }
+                }
+            }
+
+            batch.commit()?;
+            count
+        }
+        _ => 0,
+    };
+
+    let elapsed = table_start.elapsed();
+    let rate = if elapsed.as_secs() > 0 { count / elapsed.as_secs() } else { count };
+    info!(
+        target: "reth::cli",
+        table,
+        entries = count,
+        elapsed_secs = elapsed.as_secs(),
+        rate_per_sec = rate,
+        "Done"
+    );
+
+    Ok(())
+}

--- a/bin/tools/migrate_command.rs
+++ b/bin/tools/migrate_command.rs
@@ -1,0 +1,221 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::Parser;
+use eyre::Result;
+use tracing::{info, warn};
+
+use reth_chainspec::ChainSpecProvider;
+use reth_cli::chainspec::ChainSpecParser;
+use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
+use reth_db::{tables, DatabaseEnv};
+use reth_node_builder::NodeTypesWithDBAdapter;
+use reth_optimism_chainspec::OpChainSpec;
+use reth_provider::{MetadataWriter, ProviderFactory, StaticFileProviderFactory};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{BlockNumReader, DBProvider};
+
+use crate::migrate::{migrate_to_rocksdb, migrate_to_static_files};
+
+/// Migrate from legacy MDBX storage to new RocksDB + static files.
+#[derive(Debug, Parser)]
+pub struct MigrateCommand<C: ChainSpecParser> {
+    #[command(flatten)]
+    env: EnvironmentArgs<C>,
+
+    /// Block batch size for processing.
+    #[arg(long, default_value = "10000")]
+    batch_size: u64,
+
+    /// Skip static file migration.
+    #[arg(long)]
+    skip_static_files: bool,
+
+    /// Skip RocksDB migration.
+    #[arg(long)]
+    skip_rocksdb: bool,
+
+    /// Keep migrated MDBX tables (don't drop them after migration).
+    #[arg(long)]
+    keep_mdbx: bool,
+}
+
+impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> MigrateCommand<C> {
+    /// Execute the migration.
+    pub async fn execute<N>(&self) -> Result<()>
+    where
+        N: CliNodeTypes<ChainSpec = C::ChainSpec>,
+    {
+        let Environment { provider_factory, .. } = self.env.init::<N>(AccessRights::RW)?;
+
+        // Get genesis block number from chain spec
+        let genesis_block = provider_factory.chain_spec().genesis_header().number;
+
+        let provider = provider_factory.provider()?.disable_long_read_transaction_safety();
+        let to_block = provider.best_block_number()?;
+        let prune_modes = provider.prune_modes_ref().clone();
+        drop(provider);
+
+        // Validate chain state
+        if to_block < genesis_block {
+            eyre::bail!(
+                "Invalid chain state: best block {} is before genesis block {}",
+                to_block,
+                genesis_block
+            );
+        }
+
+        info!(
+            target: "reth::cli",
+            genesis_block,
+            to_block,
+            batch_size = self.batch_size,
+            "Migration parameters"
+        );
+
+        // Check if receipts can be migrated (no contract log pruning)
+        let can_migrate_receipts = prune_modes.receipts_log_filter.is_empty();
+        if !can_migrate_receipts {
+            warn!(target: "reth::cli", "Receipts will NOT be migrated due to contract log pruning");
+        }
+
+        // Start tracking time
+        let start_time = Instant::now();
+
+        // Run static files and RocksDB migrations in parallel
+        std::thread::scope(|s| {
+            let static_files_handle = if !self.skip_static_files {
+                Some(s.spawn(|| {
+                    info!(target: "reth::cli", "Starting static files migration");
+                    migrate_to_static_files::<N>(
+                        &provider_factory,
+                        genesis_block,
+                        to_block,
+                        can_migrate_receipts,
+                    )
+                }))
+            } else {
+                None
+            };
+
+            let rocksdb_handle = if !self.skip_rocksdb {
+                Some(s.spawn(|| {
+                    info!(target: "reth::cli", "Starting RocksDB migration");
+                    migrate_to_rocksdb::<N>(&provider_factory, self.batch_size)
+                }))
+            } else {
+                None
+            };
+
+            // Wait for static files migration
+            if let Some(handle) = static_files_handle {
+                handle.join().expect("static files thread panicked")?;
+            }
+
+            if let Some(handle) = rocksdb_handle {
+                handle.join().expect("rocksdb thread panicked")?;
+            }
+
+            Ok::<_, eyre::Error>(())
+        })?;
+
+        // Finalize: update storage settings and optionally drop migrated MDBX tables
+        info!(target: "reth::cli", "Finalizing migration");
+        self.finalize::<N>(&provider_factory, can_migrate_receipts)?;
+
+        let elapsed = start_time.elapsed();
+        info!(
+            target: "reth::cli",
+            elapsed_secs = elapsed.as_secs(),
+            "Migration completed"
+        );
+
+        Ok(())
+    }
+
+    fn finalize<N: CliNodeTypes>(
+        &self,
+        provider_factory: &ProviderFactory<NodeTypesWithDBAdapter<N, Arc<DatabaseEnv>>>,
+        can_migrate_receipts: bool,
+    ) -> Result<()> {
+        use reth_db_api::transaction::DbTxMut;
+        use reth_provider::StorageSettings;
+
+        let mut provider = provider_factory.provider_rw()?;
+
+        // Check if TransactionSenders actually has data in static files
+        let static_file_provider = provider_factory.static_file_provider();
+        let senders_have_data = static_file_provider
+            .get_highest_static_file_tx(StaticFileSegment::TransactionSenders)
+            .is_some();
+
+        if !senders_have_data {
+            warn!(
+                target: "reth::cli",
+                "TransactionSenders has no data in static files, not enabling static file storage for senders"
+            );
+        }
+
+        // Update storage settings - start from legacy defaults, then enable migrated features
+        let new_settings = StorageSettings::legacy()
+            .with_receipts_in_static_files(can_migrate_receipts)
+            .with_account_changesets_in_static_files(true)
+            .with_transaction_senders_in_static_files(senders_have_data)
+            .with_transaction_hash_numbers_in_rocksdb(true)
+            .with_account_history_in_rocksdb(true)
+            .with_storages_history_in_rocksdb(true);
+
+        info!(target: "reth::cli", ?new_settings, "Writing storage settings");
+        provider.write_storage_settings(new_settings)?;
+
+        // Drop migrated MDBX tables unless --keep-mdbx is set
+        if !self.keep_mdbx {
+            warn!(
+                target: "reth::cli",
+                "Clearing MDBX tables. This may take a long time (potentially hours) for large databases. Use --keep-mdbx to skip this step."
+            );
+
+            let tx = provider.tx_mut();
+
+            if !self.skip_static_files {
+                info!(target: "reth::cli", "Dropping migrated static file tables from MDBX");
+
+                info!(target: "reth::cli", "Clearing TransactionSenders table...");
+                tx.clear::<tables::TransactionSenders>()?;
+                info!(target: "reth::cli", "TransactionSenders table cleared");
+
+                info!(target: "reth::cli", "Clearing AccountChangeSets table...");
+                tx.clear::<tables::AccountChangeSets>()?;
+                info!(target: "reth::cli", "AccountChangeSets table cleared");
+
+                if can_migrate_receipts {
+                    info!(target: "reth::cli", "Clearing Receipts table...");
+                    tx.clear::<tables::Receipts<<<N as reth_node_builder::NodeTypes>::Primitives as reth_primitives_traits::NodePrimitives>::Receipt>>()?;
+                    info!(target: "reth::cli", "Receipts table cleared");
+                }
+            }
+
+            if !self.skip_rocksdb {
+                info!(target: "reth::cli", "Dropping migrated RocksDB tables from MDBX");
+
+                info!(target: "reth::cli", "Clearing TransactionHashNumbers table...");
+                tx.clear::<tables::TransactionHashNumbers>()?;
+                info!(target: "reth::cli", "TransactionHashNumbers table cleared");
+
+                info!(target: "reth::cli", "Clearing AccountsHistory table...");
+                tx.clear::<tables::AccountsHistory>()?;
+                info!(target: "reth::cli", "AccountsHistory table cleared");
+
+                info!(target: "reth::cli", "Clearing StoragesHistory table...");
+                tx.clear::<tables::StoragesHistory>()?;
+                info!(target: "reth::cli", "StoragesHistory table cleared");
+            }
+        } else {
+            info!(target: "reth::cli", "Keeping MDBX tables (--keep-mdbx)");
+        }
+
+        provider.commit()?;
+
+        Ok(())
+    }
+}

--- a/bin/tools/progress.rs
+++ b/bin/tools/progress.rs
@@ -1,0 +1,49 @@
+use std::time::Duration;
+
+use tracing::info;
+
+use reth_static_file_types::StaticFileSegment;
+
+/// Progress logging interval.
+pub(crate) const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Log progress for static file segment migration.
+pub(crate) fn log_progress(
+    segment: StaticFileSegment,
+    blocks_done: u64,
+    total_blocks: u64,
+    entries: u64,
+    elapsed: Duration,
+) {
+    let pct = (blocks_done * 100).checked_div(total_blocks).unwrap_or(0);
+    let rate = if elapsed.as_secs() > 0 { entries / elapsed.as_secs() } else { entries };
+    let eta_secs = if blocks_done > 0 && pct < 100 {
+        let remaining = total_blocks.saturating_sub(blocks_done);
+        let secs_per_block = elapsed.as_secs_f64() / blocks_done as f64;
+        (remaining as f64 * secs_per_block) as u64
+    } else {
+        0
+    };
+
+    info!(
+        target: "reth::cli",
+        ?segment,
+        progress = %format!("{blocks_done}/{total_blocks} ({pct}%)"),
+        entries,
+        rate_per_sec = rate,
+        eta_secs,
+        "Progress"
+    );
+}
+
+pub(crate) fn log_rocksdb_progress(table: &'static str, entries: u64, elapsed: Duration) {
+    let rate = if elapsed.as_secs() > 0 { entries / elapsed.as_secs() } else { entries };
+    info!(
+        target: "reth::cli",
+        table,
+        entries,
+        elapsed_secs = elapsed.as_secs(),
+        rate_per_sec = rate,
+        "Progress"
+    );
+}


### PR DESCRIPTION
## Description

Ports the legacy data migration tool from [PR #137](https://github.com/okx/xlayer-reth/pull/137) into the existing `bin/tools` binary as a new `migrate` subcommand, rather than adding a separate binary.

The `migrate` command moves data from legacy MDBX-only storage into the new RocksDB + static files layout:
- **Static files:** TransactionSenders, AccountChangeSets, Receipts
- **RocksDB:** TransactionHashNumbers, AccountsHistory, StoragesHistory

Static file and RocksDB migrations run in parallel via `std::thread::scope`, and segments within each are parallelized with `rayon`.

### New files
- `bin/tools/migrate.rs` — core migration logic for static file segments and RocksDB tables
- `bin/tools/migrate_command.rs` — CLI command struct (`--batch-size`, `--skip-static-files`, `--skip-rocksdb`, `--keep-mdbx`)
- `bin/tools/progress.rs` — progress logging with ETA

### CLI flags
| Flag | Default | Description |
|------|---------|-------------|
| `--batch-size` | 10000 | RocksDB write batch size |
| `--skip-static-files` | false | Skip static file migration |
| `--skip-rocksdb` | false | Skip RocksDB migration |
| `--keep-mdbx` | false | Don't clear migrated MDBX tables after migration |

### Notable API adaptations from PR #137
The original PR targeted an older reth revision. Key changes made during porting:
- `batch_with_auto_commit()` → `batch()` (API no longer exists)
- Removed `set_expected_block_start()` — block start is set at construction via `get_writer(genesis_block, segment)`
- `StorageSettings::base()` → `StorageSettings::legacy()`
- Removed `StorageChangeSets` segment (no longer exists in this reth revision)

### Dependency note
Enabled `reth-stages` with `rocksdb` feature as a **workaround for upstream feature unification issue**. Enabling only `reth-provider/rocksdb` causes compilation error in `reth-stages` (upstream bug at this reth revision). `reth-stages` is not actually imported/used by this code — it's only added to resolve feature flags.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Code Guidelines
Relevant guidelines:
- **[Database Guide](../docs/subguides/DATABASE_GUIDE.md)** - Changes to database tables and storage layout

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works ⚠️
- [ ] New and existing unit tests pass locally with my changes ⚠️

## Testing

⚠️ **Compilation verified** with `cargo c -p xlayer-reth-tools` — passes successfully.

⚠️ **Full test suite not run** — `just t` timed out during workspace-wide compilation. No runtime testing performed. The migration logic is adapted from PR #137 but has not been validated on the current codebase.

## Additional Notes

### ⚠️ Review priorities

1. **Dependency workaround:** The `reth-stages` with `rocksdb` feature is only added to fix feature unification, not because the tools binary uses it. Is this acceptable?

2. **Batch API semantics:** Changed from `batch_with_auto_commit()` to `batch()`. Verify this is correct — the code manually calls `batch.commit()` after every `batch_size` operations. Does `batch()` require explicit commit, or auto-commit on drop?

3. **Default MDBX clearing behavior:** By default (`--keep-mdbx` NOT set), the tool **clears the migrated MDBX tables** after migration. This is destructive and irreversible. Users must opt-in to keep MDBX data. Is this the desired UX?

4. **No checkpoint/resume for RocksDB migration:** RocksDB table migrations start from scratch each time (walk from `None`). Static file migration is resumable via `get_highest_static_file_block`, but RocksDB migration is all-or-nothing per table. Is this acceptable?

5. **Complex type for Receipts table:** Line 193 uses a turbofish with nested associated types:
   ```rust
   tx.clear::<tables::Receipts<<<N as reth_node_builder::NodeTypes>::Primitives as reth_primitives_traits::NodePrimitives>::Receipt>>()?;
   ```
   This is fragile. Verify it compiles and is correct.

6. **No tests added:** The migration logic has no unit tests. Runtime behavior is untested.

### Related
- Original PR: https://github.com/okx/xlayer-reth/pull/137
- Devin session: https://app.devin.ai/sessions/2954b9dce23c4a10bacf82ff308adc02
- Requested by: @Vui-Chee
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okx/xlayer-reth/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
