### PR TITLE
fix: bump quinn-proto to 0.11.14 to patch CVE-2026-31812 DoS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2962,7 +2962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7342,9 +7342,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

- Bumps `quinn-proto` from `0.11.13` to `0.11.14` via `cargo update --precise`
- Resolves dependabot alert [#12](https://github.com/okx/xlayer-reth/security/dependabot/12) (GHSA-6xvm-j4wr-6v98 / CVE-2026-31812)
- No reth or op crates were changed — this is a pure `Cargo.lock` update

## Background

`quinn-proto < 0.11.14` panics on attacker-controlled malformed QUIC transport parameters (`unwrap()` on `Err(UnexpectedEnd)`), allowing unauthenticated remote DoS with a single UDP packet. The fix is a patch-level bump with no API changes.

**Dependency chain:** `xlayer-builder` → `libp2p` → `libp2p-quic` → `quinn` → `quinn-proto`