### PR TITLE
feat: add Claude skills and CLAUDE.md for AI-assisted development

### DIFF
--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -1,0 +1,71 @@
+# Skill: commit
+
+Generate a well-formed conventional commit message for the current staged changes and create the commit.
+
+TRIGGER when: user asks to "commit", "create a commit", "write a commit message", or uses `/commit`.
+DO NOT TRIGGER when: user is asking about git history or how commits work in general.
+
+## Instructions
+
+### 1. Review Staged Changes
+
+Run `git diff --staged` to see all staged changes. If nothing is staged, run `git status` and inform the user.
+
+### 2. Determine Commit Type
+
+Choose the appropriate conventional commit type based on the changes:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or capability added |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring without behavior change |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `docs` | Documentation only changes |
+| `chore` | Build process, dependencies, tooling |
+| `ci` | CI/CD configuration changes |
+| `style` | Code style/formatting only (no logic change) |
+
+### 3. Determine Scope (optional)
+
+Use the crate or component name as the scope if the change is isolated:
+- `feat(rpc)`: changes in `crates/rpc/`
+- `fix(chainspec)`: changes in `crates/chainspec/`
+- `feat(flashblocks)`: changes in `crates/flashblocks/`
+- `chore(builder)`: changes in `crates/builder/`
+- Omit scope for cross-cutting changes
+
+### 4. Write the Commit Message
+
+Follow this format:
+```
+<type>(<scope>): <short description>
+
+<optional body explaining WHY the change was made>
+
+<optional footer with breaking changes or issue references>
+```
+
+Rules:
+- Subject line: imperative mood, lowercase, no period, max 72 chars
+- Body: explain motivation and context, not what the diff shows
+- Breaking changes: prefix footer with `BREAKING CHANGE:`
+- Reference issues: `Closes #<number>` or `Fixes #<number>`
+
+### 5. Create the Commit
+
+Stage the appropriate files and create the commit with the generated message.
+
+Example commit messages:
+```
+feat(rpc): add eth_getTransactionByHash override for XLayer
+
+fix(chainspec): correct genesis block timestamp for mainnet
+
+refactor(builder): extract payload validation into separate module
+
+docs: update BUILDING_ON_RETH guide with database examples
+
+chore: bump reth dependencies to v1.4.0
+```

--- a/.claude/skills/review.md
+++ b/.claude/skills/review.md
@@ -1,0 +1,74 @@
+# Skill: review
+
+Perform a thorough code review of changed files, checking for correctness, Rust best practices, XLayer-specific conventions, security issues, and test coverage.
+
+TRIGGER when: user asks to "review" code, requests a code review, or uses `/review`.
+DO NOT TRIGGER when: user only asks a question about code without requesting a review.
+
+## Instructions
+
+When invoked, perform the following code review steps in order:
+
+### 1. Identify Changed Files
+
+Read the diff or changed files. Focus on:
+- New or modified Rust source files (`*.rs`)
+- Configuration changes (`Cargo.toml`, `justfile`)
+- Documentation updates
+
+### 2. Check Rust Code Quality
+
+For each changed Rust file:
+- **Correctness**: Look for logic errors, off-by-one errors, incorrect type conversions, or incorrect use of async/await
+- **Error handling**: Ensure errors are propagated with `?` or handled explicitly; avoid `unwrap()`/`expect()` in library code (only acceptable in tests or with a clear invariant comment)
+- **Clippy compliance**: Flag patterns that would trigger `cargo clippy -- -D warnings`
+- **Formatting**: Check that code follows `rustfmt` style (consistent indentation, trailing commas in multi-line expressions)
+- **Idiomatic Rust**: Prefer `Option`/`Result` combinators, iterators over manual loops, and `From`/`Into` for type conversions
+
+### 3. Check XLayer-Specific Conventions
+
+- **Upstream compatibility**: Changes must not break upstream Reth compatibility; extensions should use trait implementations, not modifications to upstream types
+- **Component isolation**: Changes in `crates/` should be isolated to their crate; cross-crate dependencies should be minimal and intentional
+- **Database changes** (if any): Must follow `docs/subguides/DATABASE_GUIDE.md` — new tables need proper `Compress`/`Decompress` implementations
+- **RPC extensions** (if any): Must follow `docs/subguides/EXTENSION_GUIDE.md` — use the `EthApiExt` pattern
+- **Chainspec changes** (if any): Must follow `docs/subguides/CHAINSPEC_EVM_GUIDE.md`
+- **Node builder changes** (if any): Must follow `docs/subguides/NODE_BUILDER_GUIDE.md`
+
+### 4. Check Security
+
+- No hardcoded secrets, API keys, or private keys
+- Inputs from external sources (RPC, network) must be validated before use
+- Integer arithmetic that could overflow should use checked operations (`checked_add`, `saturating_add`) or explicitly handle overflow
+- No unsafe code without a `// SAFETY:` comment explaining the invariant
+- Dependencies added to `Cargo.toml` should be from trusted sources
+
+### 5. Check Tests
+
+- New public functions or changed behavior must have corresponding unit tests
+- Tests should cover both happy path and error/edge cases
+- E2e tests (in `crates/tests/`) should be added for significant new features
+- Test names should be descriptive (`test_<what>_<condition>_<expected>`)
+
+### 6. Check PR Checklist Compliance
+
+Verify against `.github/pull_request_template.md`:
+- [ ] Code follows coding standards (clippy, fmt)
+- [ ] Self-review performed
+- [ ] Hard-to-understand areas are commented
+- [ ] Tests prove the fix/feature works
+- [ ] Existing tests still pass
+
+### 7. Provide Review Summary
+
+Structure feedback as:
+
+**Summary**: Brief overview of the change and its purpose.
+
+**Issues** (if any):
+- 🔴 **Critical**: Must fix before merging (bugs, security issues, broken tests)
+- 🟡 **Warning**: Should fix (style violations, missing tests, anti-patterns)
+- 🔵 **Suggestion**: Consider improving (performance, readability, idiomatic Rust)
+
+**Positives**: Highlight good patterns or improvements worth noting.
+
+**Verdict**: `LGTM` / `Request Changes` / `Needs Discussion`

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,3 +35,4 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          custom_instructions: "Skills are available in .claude/skills/. Users can invoke them with /review or /commit in comments."

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target
 .claude
+!.claude/skills/
+!.claude/skills/*.md
 .vscode
 
 tests/data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# XLayer Reth - Claude Instructions
+
+XLayer Reth is a customized Reth (Ethereum execution client) implementation for the XLayer network, an Optimism-based Layer 2 solution. It is written in Rust and builds on top of the upstream Reth and OP-Reth codebase.
+
+## Key Commands
+
+Use `just` as the primary task runner:
+
+```bash
+just build          # Release build
+just check          # Run all checks: sweep-check, format, clippy, tests
+just test           # Run unit tests (excludes e2e)
+just check-format   # Check formatting (cargo fmt --all -- --check)
+just fix-format     # Auto-fix formatting
+just check-clippy   # Run clippy with -D warnings
+just fix-clippy     # Auto-fix clippy warnings
+just build-dev      # Dev build using local reth source
+just build-docker   # Build Docker image (DockerfileOp)
+```
+
+## Repository Structure
+
+```
+bin/
+  node/       - Main XLayer reth node binary
+  tools/      - XLayer reth tools binary
+crates/
+  builder/    - Node builder and customization
+  chainspec/  - XLayer chain specification
+  flashblocks/ - Flashblocks support (fast block streaming)
+  legacy-rpc/ - Legacy RPC compatibility
+  monitor/    - Monitoring and metrics
+  rpc/        - XLayer RPC extensions
+  tests/      - Integration and e2e tests
+  version/    - Version metadata
+docs/
+  BUILDING_ON_RETH.md           - Core extensibility guide
+  subguides/CHAINSPEC_EVM_GUIDE.md
+  subguides/DATABASE_GUIDE.md
+  subguides/ENGINE_CONSENSUS_GUIDE.md
+  subguides/EXTENSION_GUIDE.md
+  subguides/NODE_BUILDER_GUIDE.md
+  subguides/PAYLOAD_BUILDER_GUIDE.md
+```
+
+## Code Guidelines
+
+Before making changes, read the relevant guide in `docs/`:
+- **Chainspec/EVM changes**: `docs/subguides/CHAINSPEC_EVM_GUIDE.md`
+- **Database changes**: `docs/subguides/DATABASE_GUIDE.md`
+- **Engine/consensus changes**: `docs/subguides/ENGINE_CONSENSUS_GUIDE.md`
+- **Adding extensions**: `docs/subguides/EXTENSION_GUIDE.md`
+- **Node builder changes**: `docs/subguides/NODE_BUILDER_GUIDE.md`
+- **Payload builder changes**: `docs/subguides/PAYLOAD_BUILDER_GUIDE.md`
+
+## Coding Standards
+
+- All Rust code must pass `cargo clippy --all-targets --workspace -- -D warnings`
+- Code must be formatted with `cargo fmt --all`
+- New functionality must have unit tests
+- Avoid modifying upstream Reth code directly; extend via traits
+- Use idiomatic Rust: prefer `Result`/`Option` over panics in library code
+- Follow the PR template checklist (`.github/pull_request_template.md`)
+
+## Development Workflow
+
+1. Make code changes
+2. Run `just fix` to auto-fix formatting and clippy warnings
+3. Run `just check` to verify all checks pass
+4. Run `just test` to verify tests pass
+5. Commit with a descriptive message following conventional commits format
+
+## Available Skills
+
+- `/review` - Perform a thorough code review of changed files against XLayer conventions
+- `/commit` - Generate a conventional commit message for staged changes


### PR DESCRIPTION
Add Claude Code skills and project instructions to improve AI-assisted development.

- `CLAUDE.md`: project overview, commands, and coding standards for Claude
- `.claude/skills/review.md`: XLayer-aware code review skill (/review)
- `.claude/skills/commit.md`: conventional commit generation skill (/commit)

Closes #189