### PR TITLE
feat(ci): restrict to PR author as triggerman

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,6 +25,7 @@ jobs:
   authorize:
     runs-on: ubuntu-latest
     permissions: {}
+    if: "!contains(github.actor, '[bot]')"
     steps:
       - name: Check actor authorization
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,18 +27,24 @@ jobs:
     steps:
       - name: Check actor authorization
         run: |
+          ASSOCIATION="${{ github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association }}"
           PR_AUTHOR="${{ github.event.issue.user.login }}"
           if [ -z "$PR_AUTHOR" ]; then
             PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           fi
           ACTOR="${{ github.actor }}"
+          echo "Author association: $ASSOCIATION"
           echo "PR/Issue author: $PR_AUTHOR"
           echo "Triggered by: $ACTOR"
+          if [[ "$ASSOCIATION" != "OWNER" && "$ASSOCIATION" != "MEMBER" && "$ASSOCIATION" != "COLLABORATOR" ]]; then
+            echo "Unauthorized: actor '$ACTOR' is not an org member (association: '$ASSOCIATION')"
+            exit 1
+          fi
           if [[ "$ACTOR" != "$PR_AUTHOR" ]]; then
             echo "Unauthorized: '$ACTOR' is not the PR/issue author ('$PR_AUTHOR')"
             exit 1
           fi
-          echo "Authorized: '$ACTOR' is the PR/issue author"
+          echo "Authorized: '$ACTOR' is an org member and the PR/issue author"
 
   claude:
     needs: authorize

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,17 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: write
+
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false  # queue instead of cancel
+
 jobs:
   authorize:
     runs-on: ubuntu-latest
@@ -32,12 +43,6 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -56,12 +61,6 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@review'))
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
     steps:
       - name: Acknowledge trigger
         uses: actions/github-script@v7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,7 @@ concurrency:
 jobs:
   authorize:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check actor authorization
         run: |
@@ -68,6 +69,12 @@ jobs:
 
   claude-review:
     needs: authorize
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@review'))

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ permissions:
 
 concurrency:
   group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   authorize:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ permissions:
 
 concurrency:
   group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: false  # queue instead of cancel
+  cancel-in-progress: false
 
 jobs:
   authorize:
@@ -27,13 +27,18 @@ jobs:
     steps:
       - name: Check actor authorization
         run: |
-          ASSOCIATION="${{ github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association }}"
-          echo "Author association: $ASSOCIATION"
-          if [[ "$ASSOCIATION" != "OWNER" && "$ASSOCIATION" != "MEMBER" && "$ASSOCIATION" != "COLLABORATOR" ]]; then
-            echo "Unauthorized: actor '${{ github.actor }}' has association '$ASSOCIATION'"
+          PR_AUTHOR="${{ github.event.issue.user.login }}"
+          if [ -z "$PR_AUTHOR" ]; then
+            PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          fi
+          ACTOR="${{ github.actor }}"
+          echo "PR/Issue author: $PR_AUTHOR"
+          echo "Triggered by: $ACTOR"
+          if [[ "$ACTOR" != "$PR_AUTHOR" ]]; then
+            echo "Unauthorized: '$ACTOR' is not the PR/issue author ('$PR_AUTHOR')"
             exit 1
           fi
-          echo "Authorized: actor '${{ github.actor }}'"
+          echo "Authorized: '$ACTOR' is the PR/issue author"
 
   claude:
     needs: authorize

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ permissions:
 
 concurrency:
   group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   authorize:


### PR DESCRIPTION
Currently, some of our people love AI so much they trigger many actions simultaneously, but github actions can only handle at most 1 pending job request. As a result, some jobs will be dropped. Instead, we can add restrictions such as only the PR author can trigger the review and he/she can submit 1 job request at a time. AI can respond to many comments in 1 PR in 1 trigger instead of many.

This PR also prevents trigger when bot responds.