### PR TITLE
fix: update security workflow

### DIFF
--- a/.github/workflows/security-dependabot-fix.yml
+++ b/.github/workflows/security-dependabot-fix.yml
@@ -29,6 +29,9 @@ jobs:
           # applied inline on the gh command so it always wins.
           # Requires a fine-grained PAT with "Dependabot alerts: Read" permission.
           GH_TOKEN: ${{ secrets.GH_SECURITY_PAT }}
+          # Needed for listing PRs (pull-requests: write is granted in the permissions block).
+          # GH_SECURITY_PAT only has Dependabot alerts read access, not PR access.
+          WORKFLOW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "::error::GH_SECURITY_PAT secret is not set. Add a fine-grained PAT with 'Dependabot alerts: Read' permission."
@@ -67,16 +70,25 @@ jobs:
             }
           ] | sort_by(.severity_rank)' /tmp/alerts_raw.json > /tmp/alerts_all.json
 
-          # Collect alert numbers that already have an open PR (branch: fix/security-*-<number>).
-          # The alert number is always the last dash-separated segment of the branch name.
-          HANDLED_NUMS=$(gh pr list --state open --json headRefName \
-            --jq '[.[].headRefName | select(startswith("fix/security-")) | split("-") | last] | unique' \
-            2>/dev/null || echo '[]')
-          echo "Alert numbers with existing open PRs: $HANDLED_NUMS"
+          # Collect branch names of open security PRs.
+          # Use GITHUB_TOKEN here — GH_SECURITY_PAT only has Dependabot alerts read access
+          # and cannot list pull requests, which would silently return [] and break deduplication.
+          # We match by package name (not alert number) because a single package can have
+          # multiple CVE alerts and a single PR may resolve several of them at once.
+          PR_BRANCHES=$(GH_TOKEN="$WORKFLOW_GITHUB_TOKEN" gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open --limit 100 --json headRefName \
+            --jq '[.[].headRefName | select(startswith("fix/security-"))]' \
+            || echo '[]')
+          echo "Open security PR branches: $PR_BRANCHES"
 
-          # Filter out already-handled alerts, then take the top 2 remaining.
-          jq --argjson handled "$HANDLED_NUMS" '
-            [.[] | select((.number | tostring) as $n | ($handled | index($n)) == null)] | .[0:2]
+          # Filter out alerts whose package already has an open security PR.
+          # For each alert, check if any open branch starts with fix/security-<package>-.
+          jq --argjson branches "$PR_BRANCHES" '
+            [.[] | select(
+              .package as $pkg |
+              ($branches | map(startswith("fix/security-\($pkg)-")) | any) | not
+            )] | .[0:2]
           ' /tmp/alerts_all.json > /tmp/alerts.json
 
           COUNT=$(jq 'length' /tmp/alerts.json)


### PR DESCRIPTION
## Description

Fixes and hardens the `security-dependabot-fix` workflow so it reliably detects, deduplicates, and auto-patches Dependabot security alerts without creating duplicate PRs.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

### Fix: use `gh` CLI instead of `github-script` for alert fetching
The `github-script` REST client was silently swallowing API errors (e.g. auth/permission failures), leaving `has_alerts=false` and skipping all downstream steps with no visible error. Switching to the `gh` CLI means failures exit loudly with a clear message.

### Fix: Dependabot alerts API requires a fine-grained PAT
`GITHUB_TOKEN` returns 404 on the Dependabot alerts endpoint regardless of the `security-events: read` permission — GitHub maps that scope to code scanning, not Dependabot. A fine-grained PAT (`GH_SECURITY_PAT`) with "Dependabot alerts: Read" is required. Raw JSON is now fetched to a file first so a `gh api` error is caught before `jq` runs (fixes the `Cannot index string` error that followed the 404).

### Fix: avoid `GH_TOKEN` collision with the runner pre-set value
GitHub Actions runners automatically set `GH_TOKEN=GITHUB_TOKEN` for the `gh` CLI before any step runs. Setting `GH_TOKEN` in the step `env` block with the PAT was silently overridden by the runner. Fix: store the PAT as a distinctly-named env var (`GH_SECURITY_PAT`) and apply it inline (`GH_TOKEN="$GH_SECURITY_PAT" gh api ...`) so the shell-level assignment wins.

### Fix: `gh pr list` used the wrong token for deduplication
The existing-PR check (`gh pr list`) ran under `GH_SECURITY_PAT`, which only has "Dependabot alerts: Read" and cannot list pull requests. The command failed silently (`2>/dev/null || echo '[]'`), making every alert appear unhandled on every run. Fix: use `GITHUB_TOKEN` (which has `pull-requests: write`) for the PR list call.

### Fix: deduplicate by package name, not alert number
The original filter extracted the alert number from the branch name (`split("-") | last`) and matched it against each alert's `.number`. A single package can have multiple CVE alerts, and a single PR can fix all of them under one branch named after the first alert. Subsequent alerts for the same package were never matched and triggered duplicate PRs. Fix: match by package name — skip any alert whose package already has an open `fix/security-<package>-*` branch.

### Fix: use dynamic default branch
Replaced the hardcoded `main` reference with `${{ github.event.repository.default_branch }}` so the workflow works on repos whose default branch is not named `main`.

### Fix: correct `allowedTools` parameter for `claude-code-action`
`allowed_tools` is not a valid input for `claude-code-action`; the correct form is `claude_args: "--allowedTools Bash,Read,Write,Edit,Glob,Grep"`. The invalid key was silently ignored, leaving Claude with no tool permissions and causing repeated permission denials.

### Refactor: pre-select alerts in `jq` before Claude runs
Filter to critical/high/medium severity, sort by severity rank, check for existing PRs, and write the final top-2 list to `/tmp/alerts.json` before Claude is invoked. This removes all in-prompt budget logic, keeps the Claude prompt focused on fixing, and prevents prompt injection (advisory text is written to a file, never interpolated into the prompt).

## Checklist
- [x] I have reviewed the relevant code guidelines in the `docs/` folder
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code