### PR TITLE
feat(builder): add builder p2p and flashblocks reorg protection for default optimism builder

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -134,6 +134,7 @@ fn main() {
             let payload_builder = XLayerPayloadServiceBuilder::new(
                 args.xlayer_args.builder.clone(),
                 args.rollup_args.compute_pending_block,
+                xlayer_args.sequencer_mode,
             )?
             .with_bridge_config(bridge_config);
 

--- a/bin/node/src/payload.rs
+++ b/bin/node/src/payload.rs
@@ -1,7 +1,8 @@
 use reth::builder::components::PayloadServiceBuilder;
 use reth_node_api::NodeTypes;
-use reth_node_builder::BuilderContext;
+use reth_node_builder::{components::BasicPayloadServiceBuilder, BuilderContext};
 use reth_optimism_evm::OpEvmConfig;
+use reth_optimism_node::node::OpPayloadBuilder;
 use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 use xlayer_bridge_intercept::BridgeInterceptConfig;
 use xlayer_builder::{
@@ -17,7 +18,9 @@ enum XLayerPayloadServiceBuilderInner {
     Flashblocks(Box<FlashblocksServiceBuilder>),
     /// Uses [`DefaultBuilderServiceBuilder`] that wraps the default OP builder with
     /// builder p2p and flashblocks reorg protection.
-    Default(Box<DefaultBuilderServiceBuilder>),
+    DefaultWithP2P(Box<DefaultBuilderServiceBuilder>),
+    /// Uses [`BasicPayloadServiceBuilder`] with [`OpPayloadBuilder`] for RPC nodes.
+    Default(BasicPayloadServiceBuilder<OpPayloadBuilder>),
 }
 
 /// The X Layer payload service builder that builds [`FlashblocksServiceBuilder`] if
@@ -30,10 +33,12 @@ impl XLayerPayloadServiceBuilder {
     pub fn new(
         xlayer_builder_args: BuilderArgs,
         compute_pending_block: bool,
+        sequencer_mode: bool,
     ) -> eyre::Result<Self> {
         Self::with_config(
             xlayer_builder_args,
             compute_pending_block,
+            sequencer_mode,
             OpDAConfig::default(),
             OpGasLimitConfig::default(),
         )
@@ -42,23 +47,35 @@ impl XLayerPayloadServiceBuilder {
     pub fn with_config(
         xlayer_builder_args: BuilderArgs,
         compute_pending_block: bool,
+        sequencer_mode: bool,
         da_config: OpDAConfig,
         gas_limit_config: OpGasLimitConfig,
     ) -> eyre::Result<Self> {
         let flashblocks_enabled = xlayer_builder_args.flashblocks.enabled;
         let config = BuilderConfig::try_from(xlayer_builder_args)?;
-        let builder = if flashblocks_enabled {
-            XLayerPayloadServiceBuilderInner::Flashblocks(Box::new(FlashblocksServiceBuilder {
-                config,
-                bridge_intercept: Default::default(),
-            }))
+        let builder = if sequencer_mode {
+            if flashblocks_enabled {
+                XLayerPayloadServiceBuilderInner::Flashblocks(Box::new(FlashblocksServiceBuilder {
+                    config,
+                    bridge_intercept: Default::default(),
+                }))
+            } else {
+                XLayerPayloadServiceBuilderInner::DefaultWithP2P(Box::new(
+                    DefaultBuilderServiceBuilder {
+                        compute_pending_block,
+                        config,
+                        da_config,
+                        gas_limit_config,
+                    },
+                ))
+            }
         } else {
-            XLayerPayloadServiceBuilderInner::Default(Box::new(DefaultBuilderServiceBuilder {
-                compute_pending_block,
-                config,
-                da_config,
-                gas_limit_config,
-            }))
+            let payload_builder = OpPayloadBuilder::new(compute_pending_block)
+                .with_da_config(da_config)
+                .with_gas_limit_config(gas_limit_config);
+            XLayerPayloadServiceBuilderInner::Default(BasicPayloadServiceBuilder::new(
+                payload_builder,
+            ))
         };
         Ok(Self { builder })
     }
@@ -88,8 +105,11 @@ where
             XLayerPayloadServiceBuilderInner::Flashblocks(flashblocks_builder) => {
                 flashblocks_builder.spawn_payload_builder_service(ctx, pool, evm_config).await
             }
-            XLayerPayloadServiceBuilderInner::Default(default_builder) => {
+            XLayerPayloadServiceBuilderInner::DefaultWithP2P(default_builder) => {
                 default_builder.spawn_payload_builder_service(ctx, pool, evm_config).await
+            }
+            XLayerPayloadServiceBuilderInner::Default(basic_builder) => {
+                basic_builder.spawn_payload_builder_service(ctx, pool, evm_config).await
             }
         }
     }

--- a/bin/node/src/payload.rs
+++ b/bin/node/src/payload.rs
@@ -1,12 +1,12 @@
 use reth::builder::components::PayloadServiceBuilder;
 use reth_node_api::NodeTypes;
-use reth_node_builder::{components::BasicPayloadServiceBuilder, BuilderContext};
+use reth_node_builder::BuilderContext;
 use reth_optimism_evm::OpEvmConfig;
-use reth_optimism_node::node::OpPayloadBuilder;
 use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 use xlayer_bridge_intercept::BridgeInterceptConfig;
 use xlayer_builder::{
     args::BuilderArgs,
+    default::DefaultBuilderServiceBuilder,
     flashblocks::{BuilderConfig, FlashblocksServiceBuilder},
     traits::{NodeBounds, PoolBounds},
 };
@@ -15,12 +15,13 @@ use xlayer_builder::{
 enum XLayerPayloadServiceBuilderInner {
     /// Uses [`FlashblocksServiceBuilder`] for sequencer nodes producing flashblocks.
     Flashblocks(Box<FlashblocksServiceBuilder>),
-    /// Uses [`BasicPayloadServiceBuilder`] with [`OpPayloadBuilder`] for follower/RPC nodes.
-    Default(BasicPayloadServiceBuilder<OpPayloadBuilder>),
+    /// Uses [`DefaultBuilderServiceBuilder`] that wraps the default OP builder with
+    /// builder p2p and flashblocks reorg protection.
+    Default(Box<DefaultBuilderServiceBuilder>),
 }
 
-/// The X Layer payload service builder that delegates to either [`FlashblocksServiceBuilder`]
-/// or the default [`BasicPayloadServiceBuilder`].
+/// The X Layer payload service builder that builds [`FlashblocksServiceBuilder`] if
+/// flashblocks are enabled, otherwise builds [`DefaultBuilderServiceBuilder`].
 pub struct XLayerPayloadServiceBuilder {
     builder: XLayerPayloadServiceBuilderInner,
 }
@@ -44,21 +45,21 @@ impl XLayerPayloadServiceBuilder {
         da_config: OpDAConfig,
         gas_limit_config: OpGasLimitConfig,
     ) -> eyre::Result<Self> {
-        let builder = if xlayer_builder_args.flashblocks.enabled {
-            let builder_config = BuilderConfig::try_from(xlayer_builder_args)?;
+        let flashblocks_enabled = xlayer_builder_args.flashblocks.enabled;
+        let config = BuilderConfig::try_from(xlayer_builder_args)?;
+        let builder = if flashblocks_enabled {
             XLayerPayloadServiceBuilderInner::Flashblocks(Box::new(FlashblocksServiceBuilder {
-                config: builder_config,
+                config,
                 bridge_intercept: Default::default(),
             }))
         } else {
-            let payload_builder = OpPayloadBuilder::new(compute_pending_block)
-                .with_da_config(da_config)
-                .with_gas_limit_config(gas_limit_config);
-            XLayerPayloadServiceBuilderInner::Default(BasicPayloadServiceBuilder::new(
-                payload_builder,
-            ))
+            XLayerPayloadServiceBuilderInner::Default(Box::new(DefaultBuilderServiceBuilder {
+                compute_pending_block,
+                config,
+                da_config,
+                gas_limit_config,
+            }))
         };
-
         Ok(Self { builder })
     }
 
@@ -85,12 +86,10 @@ where
     {
         match self.builder {
             XLayerPayloadServiceBuilderInner::Flashblocks(flashblocks_builder) => {
-                // Use FlashblocksServiceBuilder
                 flashblocks_builder.spawn_payload_builder_service(ctx, pool, evm_config).await
             }
-            XLayerPayloadServiceBuilderInner::Default(basic_builder) => {
-                // Use BasicPayloadServiceBuilder - it handles all the boilerplate!
-                basic_builder.spawn_payload_builder_service(ctx, pool, evm_config).await
+            XLayerPayloadServiceBuilderInner::Default(default_builder) => {
+                default_builder.spawn_payload_builder_service(ctx, pool, evm_config).await
             }
         }
     }

--- a/bin/node/src/payload.rs
+++ b/bin/node/src/payload.rs
@@ -52,8 +52,8 @@ impl XLayerPayloadServiceBuilder {
         gas_limit_config: OpGasLimitConfig,
     ) -> eyre::Result<Self> {
         let flashblocks_enabled = xlayer_builder_args.flashblocks.enabled;
-        let config = BuilderConfig::try_from(xlayer_builder_args)?;
         let builder = if sequencer_mode {
+            let config = BuilderConfig::try_from(xlayer_builder_args)?;
             if flashblocks_enabled {
                 XLayerPayloadServiceBuilderInner::Flashblocks(Box::new(FlashblocksServiceBuilder {
                     config,
@@ -80,10 +80,18 @@ impl XLayerPayloadServiceBuilder {
         Ok(Self { builder })
     }
 
-    /// Apply bridge intercept config to the flashblocks builder.
+    /// Apply bridge intercept config. Only the flashblocks builder supports bridge
+    /// intercept — the default builder runs unmodified upstream `OpPayloadBuilder` logic
+    /// as a failsafe, so bridge filtering is intentionally not applied.
     pub fn with_bridge_config(mut self, config: BridgeInterceptConfig) -> Self {
-        if let XLayerPayloadServiceBuilderInner::Flashblocks(ref mut fb) = self.builder {
-            fb.with_bridge_intercept(config);
+        match &mut self.builder {
+            XLayerPayloadServiceBuilderInner::Flashblocks(fb) => {
+                fb.with_bridge_intercept(config);
+            }
+            // DefaultWithP2P runs the upstream OpPayloadBuilder as a failsafe during
+            // conductor failover — bridge intercept is not supported on this path.
+            XLayerPayloadServiceBuilderInner::DefaultWithP2P(_) => {}
+            XLayerPayloadServiceBuilderInner::Default(_) => {}
         }
         self
     }

--- a/crates/builder/src/default/builder.rs
+++ b/crates/builder/src/default/builder.rs
@@ -1,0 +1,296 @@
+//! Default payload builder wrapper with flashblocks cache replay.
+//!
+//! Wraps [`reth_optimism_payload_builder::OpPayloadBuilder`] and intercepts
+//! `try_build` to check the [`FlashblockPayloadsCache`] before delegating.
+//! On cache hit, cached transactions are replayed via `BlockBuilder::execute_transaction`
+//! and the payload is returned as `Freeze` (deterministic, no re-building).
+
+use crate::flashblocks::utils::cache::FlashblockPayloadsCache;
+
+use alloy_consensus::{transaction::TxHashRef, Transaction, Typed2718};
+use alloy_eips::eip2718::WithEncoded;
+use alloy_evm::Evm as _;
+use alloy_primitives::U256;
+use op_alloy_consensus::OpTransaction;
+use reth_basic_payload_builder::*;
+use reth_chainspec::ChainSpecProvider;
+use reth_evm::{
+    execute::{BlockBuilder, BlockBuilderOutcome, BlockExecutionError},
+    op_revm::constants::L1_BLOCK_CONTRACT,
+    ConfigureEvm,
+};
+use reth_execution_types::BlockExecutionOutput;
+use reth_optimism_forks::OpHardforks;
+use reth_optimism_payload_builder::{
+    builder::OpPayloadBuilderCtx, builder::OpPayloadTransactions, error::OpPayloadBuilderError,
+    payload::OpBuiltPayload, OpAttributes, OpPayloadPrimitives,
+};
+use reth_optimism_txpool::OpPooledTx;
+use reth_payload_builder_primitives::PayloadBuilderError;
+use reth_payload_primitives::{BuildNextEnv, BuiltPayloadExecutedBlock};
+use reth_revm::{database::StateProviderDatabase, db::State};
+use reth_storage_api::StateProviderFactory;
+use reth_transaction_pool::TransactionPool;
+use revm::context::Block as _;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+/// The default optimism payload builder that wraps the additional builder p2p node
+/// with flashblocks cache replay support. This is for flashblocks reorg protection
+/// on failover to the default builder (when `flashblocks.enabled` = false).
+///
+/// When the P2P flashblocks sequence cache matches the current parent hash, cached
+/// transactions are replayed instead of pulling from the txpool. Otherwise, payload
+/// building is handled by the [`reth_optimism_payload_builder::OpPayloadBuilder`].
+pub struct DefaultPayloadBuilder<Pool, Client, Evm, Txs, Attrs> {
+    /// The inner default OP payload builder.
+    inner: reth_optimism_payload_builder::OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>,
+    /// Cache of flashblock payloads received via P2P, keyed by parent hash.
+    p2p_cache: FlashblockPayloadsCache,
+}
+
+impl<Pool, Client, Evm, Txs, Attrs> DefaultPayloadBuilder<Pool, Client, Evm, Txs, Attrs> {
+    /// Creates a new [`DefaultPayloadBuilder`] wrapping the given inner builder.
+    pub fn new(
+        inner: reth_optimism_payload_builder::OpPayloadBuilder<Pool, Client, Evm, Txs, Attrs>,
+        p2p_cache: FlashblockPayloadsCache,
+    ) -> Self {
+        Self { inner, p2p_cache }
+    }
+}
+
+impl<Pool: Clone, Client: Clone, Evm: ConfigureEvm + Clone, Txs: Clone, Attrs> Clone
+    for DefaultPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
+{
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone(), p2p_cache: self.p2p_cache.clone() }
+    }
+}
+
+impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
+    for DefaultPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
+where
+    N: OpPayloadPrimitives,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: OpHardforks> + Clone,
+    Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
+    Evm: ConfigureEvm<
+        Primitives = N,
+        NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
+    >,
+    Txs: OpPayloadTransactions<Pool::Transaction>,
+    Attrs: OpAttributes<Transaction = N::SignedTx>,
+{
+    type Attributes = Attrs;
+    type BuiltPayload = OpBuiltPayload<N>;
+
+    fn try_build(
+        &self,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+    ) -> Result<BuildOutcome<Self::BuiltPayload>, PayloadBuilderError> {
+        let parent_hash = args.config.parent_header.hash();
+
+        // Check P2P cache for a flashblocks sequence matching this parent
+        if let Some(cached_txs) = self
+            .p2p_cache
+            .get_flashblocks_sequence_txs::<N::SignedTx>(parent_hash)
+            .filter(|txs| !txs.is_empty())
+        {
+            info!(
+                target: "payload_builder",
+                parent_hash = %parent_hash,
+                cached_tx_count = cached_txs.len(),
+                "Cache hit: replaying cached flashblocks transactions in default builder"
+            );
+            return self.build_with_cached_txs(args, cached_txs);
+        }
+
+        // Cache miss: delegate entirely to the inner OP builder
+        self.inner.try_build(args)
+    }
+
+    fn on_missing_payload(
+        &self,
+        args: BuildArguments<Self::Attributes, Self::BuiltPayload>,
+    ) -> MissingPayloadBehaviour<Self::BuiltPayload> {
+        self.inner.on_missing_payload(args)
+    }
+
+    fn build_empty_payload(
+        &self,
+        config: PayloadConfig<Self::Attributes, N::BlockHeader>,
+    ) -> Result<Self::BuiltPayload, PayloadBuilderError> {
+        self.inner.build_empty_payload(config)
+    }
+}
+
+impl<Pool, Client, Evm, N, Txs, Attrs> DefaultPayloadBuilder<Pool, Client, Evm, Txs, Attrs>
+where
+    N: OpPayloadPrimitives,
+    Client: StateProviderFactory + ChainSpecProvider<ChainSpec: OpHardforks> + Clone,
+    Pool: TransactionPool<Transaction: OpPooledTx<Consensus = N::SignedTx>>,
+    Evm: ConfigureEvm<
+        Primitives = N,
+        NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
+    >,
+    Txs: OpPayloadTransactions<Pool::Transaction>,
+    Attrs: OpAttributes<Transaction = N::SignedTx>,
+{
+    /// Builds a payload by replaying cached flashblocks transactions.
+    ///
+    /// Replicates the [`OpBuilder::build`] flow but replaces `execute_best_transactions`
+    /// with direct cached transaction execution via [`BlockBuilder::execute_transaction`].
+    fn build_with_cached_txs(
+        &self,
+        args: BuildArguments<Attrs, OpBuiltPayload<N>>,
+        cached_txs: Vec<WithEncoded<alloy_consensus::transaction::Recovered<N::SignedTx>>>,
+    ) -> Result<BuildOutcome<OpBuiltPayload<N>>, PayloadBuilderError> {
+        let BuildArguments { mut cached_reads, config, cancel, best_payload } = args;
+
+        let ctx = OpPayloadBuilderCtx {
+            evm_config: self.inner.evm_config.clone(),
+            builder_config: self.inner.config.clone(),
+            chain_spec: self.inner.client.chain_spec(),
+            config,
+            cancel,
+            best_payload,
+        };
+
+        let state_provider = self.inner.client.state_by_block_hash(ctx.parent().hash())?;
+        let state = StateProviderDatabase::new(&state_provider);
+        let mut db = State::builder()
+            .with_database(cached_reads.as_db_mut(state))
+            .with_bundle_update()
+            .build();
+
+        // Pre-load L1 block contract into cache (required for DA footprint gas scalar)
+        db.load_cache_account(L1_BLOCK_CONTRACT).map_err(BlockExecutionError::other)?;
+
+        let mut builder = ctx.block_builder(&mut db)?;
+
+        // 1. Apply pre-execution changes (system calls)
+        builder.apply_pre_execution_changes().map_err(|err| {
+            warn!(target: "payload_builder", %err, "failed to apply pre-execution changes during cache replay");
+            PayloadBuilderError::Internal(err.into())
+        })?;
+
+        // 2. Execute sequencer transactions from payload attributes
+        let mut info = ctx.execute_sequencer_transactions(&mut builder)?;
+
+        // 3. Execute cached transactions (replaces execute_best_transactions)
+        let mut block_gas_limit = builder.evm_mut().block().gas_limit();
+        if let Some(gas_limit_config) = ctx.builder_config.gas_limit_config.gas_limit() {
+            // If a gas limit is configured, use that limit as target if it's smaller, otherwise use
+            // the block's actual gas limit.
+            block_gas_limit = gas_limit_config.min(block_gas_limit);
+        }
+        let block_da_limit = ctx.builder_config.da_config.max_da_block_size();
+        let tx_da_limit = ctx.builder_config.da_config.max_da_tx_size();
+        let base_fee = builder.evm_mut().block().basefee();
+
+        // The execution result is discarded here since even on replay errors, we
+        // will resolve the payload tillwhichever point the replay failed.
+        let _ = execute_cached_transactions::<N, _>(
+            &mut info,
+            &mut builder,
+            cached_txs,
+            base_fee,
+            block_gas_limit,
+            tx_da_limit,
+            block_da_limit,
+        )
+        .inspect_err(|e| {
+            warn!(
+                target: "payload_builder",
+                "Failed replaying cached flashblocks sequence fully, error: {e}",
+            );
+        });
+
+        // 4. Finish: compute state root, transaction root, receipt root
+        let BlockBuilderOutcome { execution_result, hashed_state, trie_updates, block } =
+            builder.finish(&state_provider)?;
+
+        let sealed_block = Arc::new(block.sealed_block().clone());
+
+        let execution_outcome =
+            BlockExecutionOutput { state: db.take_bundle(), result: execution_result };
+
+        let executed: BuiltPayloadExecutedBlock<N> = BuiltPayloadExecutedBlock {
+            recovered_block: Arc::new(block),
+            execution_output: Arc::new(execution_outcome),
+            hashed_state: either::Either::Left(Arc::new(hashed_state)),
+            trie_updates: either::Either::Left(Arc::new(trie_updates)),
+        };
+
+        let payload =
+            OpBuiltPayload::new(ctx.payload_id(), sealed_block, info.total_fees, Some(executed));
+
+        info!(
+            target: "payload_builder",
+            id = %ctx.payload_id(),
+            block_hash = %payload.block().hash(),
+            "Successfully built payload from cached flashblocks transactions"
+        );
+
+        // Freeze: deterministic payload from cached sequence, no re-building needed
+        Ok(BuildOutcomeKind::Freeze(payload).with_cached_reads(cached_reads))
+    }
+}
+
+/// Executes cached flashblocks transactions via [`BlockBuilder::execute_transaction`].
+fn execute_cached_transactions<N, Builder>(
+    info: &mut reth_optimism_payload_builder::builder::ExecutionInfo,
+    builder: &mut Builder,
+    cached_txs: Vec<WithEncoded<alloy_consensus::transaction::Recovered<N::SignedTx>>>,
+    base_fee: u64,
+    block_gas_limit: u64,
+    tx_da_limit: Option<u64>,
+    block_da_limit: Option<u64>,
+) -> Result<(), PayloadBuilderError>
+where
+    N: OpPayloadPrimitives,
+    Builder: BlockBuilder<Primitives = N>,
+{
+    for tx_encoded in cached_txs {
+        let (encoded_bytes, recovered_tx) = tx_encoded.split();
+
+        // ensure transaction is valid
+        let tx_da_size = op_alloy_flz::tx_estimated_size_fjord_bytes(encoded_bytes.as_ref());
+        if info.is_tx_over_limits(
+            tx_da_size,
+            block_gas_limit,
+            tx_da_limit,
+            block_da_limit,
+            recovered_tx.gas_limit(),
+            None, // DA footprint gas scalar — skipped (requires L1BlockInfo DB fetch)
+        ) {
+            return Err(PayloadBuilderError::Other(
+                eyre::eyre!(
+                    "invalid flashblocks sequence, tx {} over block limits",
+                    recovered_tx.tx_hash(),
+                )
+                .into(),
+            ));
+        }
+        if recovered_tx.is_eip4844() {
+            return Err(PayloadBuilderError::other(OpPayloadBuilderError::BlobTransactionRejected));
+        }
+        if recovered_tx.is_deposit() {
+            return Err(PayloadBuilderError::Other(
+                eyre::eyre!("invalid flashblocks sequence, deposit transaction rejected").into(),
+            ));
+        }
+
+        // Ensure transaction execution is valid
+        let gas_used = builder
+            .execute_transaction(recovered_tx.clone())
+            .map_err(|err| PayloadBuilderError::EvmExecutionError(Box::new(err)))?;
+
+        // Track fees for payload metadata
+        let miner_fee = recovered_tx
+            .effective_tip_per_gas(base_fee)
+            .expect("fee is always valid; execution succeeded");
+        info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
+    }
+
+    Ok(())
+}

--- a/crates/builder/src/default/builder.rs
+++ b/crates/builder/src/default/builder.rs
@@ -188,7 +188,7 @@ where
         let base_fee = builder.evm_mut().block().basefee();
 
         // The execution result is discarded here since even on replay errors, we
-        // will resolve the payload tillwhichever point the replay failed.
+        // will resolve the payload till whichever point the replay failed.
         let _ = execute_cached_transactions::<N, _>(
             &mut info,
             &mut builder,
@@ -284,6 +284,9 @@ where
         let gas_used = builder
             .execute_transaction(recovered_tx.clone())
             .map_err(|err| PayloadBuilderError::EvmExecutionError(Box::new(err)))?;
+
+        info.cumulative_gas_used += gas_used;
+        info.cumulative_da_bytes_used += tx_da_size;
 
         // Track fees for payload metadata
         let miner_fee = recovered_tx

--- a/crates/builder/src/default/handler.rs
+++ b/crates/builder/src/default/handler.rs
@@ -1,0 +1,72 @@
+//! P2P message handler for the default builder's reorg protection.
+//!
+//! Routes incoming flashblock messages from P2P peers to the
+//! [`FlashblockPayloadsCache`] for replay on failover, and optionally
+//! relays them to downstream WebSocket subscribers.
+
+use crate::{
+    broadcast::{Message, WebSocketPublisher, XLayerFlashblockMessage},
+    flashblocks::utils::cache::FlashblockPayloadsCache,
+};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+/// Handles P2P-received flashblock messages for the default (non-flashblocks) builder.
+///
+/// Unlike [`FlashblocksPayloadHandler`](crate::flashblocks::handler), this handler
+/// only accumulates incoming flashblocks into the cache and relays them via WebSocket.
+/// It does not broadcast locally built payloads (the default builder does not produce
+/// flashblocks).
+pub(crate) struct DefaultPayloadHandler {
+    /// Receives incoming P2P messages from peers.
+    p2p_rx: mpsc::Receiver<Message>,
+    /// Cache for externally received pending flashblock transactions.
+    p2p_cache: FlashblockPayloadsCache,
+    /// WebSocket publisher for relaying flashblocks to downstream subscribers.
+    ws_pub: Arc<WebSocketPublisher>,
+    /// Cancellation token for graceful shutdown.
+    cancel: tokio_util::sync::CancellationToken,
+}
+
+impl DefaultPayloadHandler {
+    pub(crate) fn new(
+        p2p_rx: mpsc::Receiver<Message>,
+        p2p_cache: FlashblockPayloadsCache,
+        ws_pub: Arc<WebSocketPublisher>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        Self { p2p_rx, p2p_cache, ws_pub, cancel }
+    }
+
+    /// Runs the handler event loop until cancellation or channel close.
+    pub(crate) async fn run(mut self) {
+        tracing::info!(target: "payload_builder", "default builder P2P payload handler started");
+
+        loop {
+            tokio::select! {
+                Some(message) = self.p2p_rx.recv() => {
+                    match message {
+                        Message::OpFlashblockPayload(fb_payload) => {
+                            if let XLayerFlashblockMessage::Payload(payload) = &fb_payload &&
+                                let Err(e) = self.p2p_cache.add_flashblock_payload(payload.inner.clone()) {
+                                warn!(target: "payload_builder", e = ?e, "failed to add flashblock txs to cache");
+                            }
+                            if let Err(e) = self.ws_pub.publish(&fb_payload) {
+                                warn!(target: "payload_builder", e = ?e, "failed to publish flashblock to websocket publisher");
+                            }
+                        }
+                        Message::OpBuiltPayload(_) => {
+                            // Full built payloads are not processed by the default builder handler
+                        }
+                    }
+                }
+                _ = self.cancel.cancelled() => {
+                    tracing::info!(target: "payload_builder", "default builder P2P payload handler shutting down");
+                    break;
+                }
+                else => break,
+            }
+        }
+    }
+}

--- a/crates/builder/src/default/handler.rs
+++ b/crates/builder/src/default/handler.rs
@@ -48,9 +48,8 @@ impl DefaultPayloadHandler {
                 Some(message) = self.p2p_rx.recv() => {
                     match message {
                         Message::OpFlashblockPayload(fb_payload) => {
-                            if let XLayerFlashblockMessage::Payload(payload) = &fb_payload &&
-                                let Err(e) = self.p2p_cache.add_flashblock_payload(payload.inner.clone()) {
-                                warn!(target: "payload_builder", e = ?e, "failed to add flashblock txs to cache");
+                            if let XLayerFlashblockMessage::Payload(payload) = &fb_payload {
+                                self.p2p_cache.add_flashblock_payload(payload.inner.clone());
                             }
                             if let Err(e) = self.ws_pub.publish(&fb_payload) {
                                 warn!(target: "payload_builder", e = ?e, "failed to publish flashblock to websocket publisher");

--- a/crates/builder/src/default/mod.rs
+++ b/crates/builder/src/default/mod.rs
@@ -1,0 +1,12 @@
+//! Default OP builder wrapper with reorg protection.
+//!
+//! Wraps the standard `OpPayloadBuilder` with P2P flashblocks cache accumulation
+//! and cached transaction replay on conductor-driven failover. This module is used
+//! when `flashblocks.enabled=false`.
+
+mod builder;
+mod handler;
+mod service;
+
+pub use builder::DefaultPayloadBuilder;
+pub use service::DefaultBuilderServiceBuilder;

--- a/crates/builder/src/default/service.rs
+++ b/crates/builder/src/default/service.rs
@@ -1,0 +1,154 @@
+//! Default builder service with P2P reorg protection.
+//!
+//! [`DefaultBuilderServiceBuilder`] implements `PayloadServiceBuilder` and wires together:
+//! - The P2P node (reuses [`broadcast::NodeBuilder`])
+//! - The [`FlashblockPayloadsCache`] (shared between handler and builder)
+//! - The [`DefaultPayloadBuilder`] (wraps `OpPayloadBuilder` + cache)
+//! - The [`DefaultPayloadHandler`] (routes P2P messages to cache)
+
+use crate::{
+    broadcast::{
+        types::{AGENT_VERSION, FLASHBLOCKS_STREAM_PROTOCOL},
+        wspub::WebSocketPublisher,
+    },
+    default::{handler::DefaultPayloadHandler, DefaultPayloadBuilder},
+    flashblocks::{utils::cache::FlashblockPayloadsCache, BuilderConfig},
+    metrics::{tokio::FlashblocksTaskMetrics, BuilderMetrics},
+    traits::{NodeBounds, PoolBounds},
+};
+use eyre::WrapErr as _;
+use std::sync::Arc;
+
+use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
+use reth_node_api::NodeTypes;
+use reth_node_builder::{components::PayloadServiceBuilder, BuilderContext};
+use reth_optimism_evm::OpEvmConfig;
+use reth_optimism_payload_builder::config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig};
+use reth_payload_builder::{PayloadBuilderHandle, PayloadBuilderService};
+use reth_provider::CanonStateSubscriptions;
+
+pub struct DefaultBuilderServiceBuilder {
+    pub compute_pending_block: bool,
+    pub config: BuilderConfig,
+    pub da_config: OpDAConfig,
+    pub gas_limit_config: OpGasLimitConfig,
+}
+
+impl<Node, Pool> PayloadServiceBuilder<Node, Pool, OpEvmConfig> for DefaultBuilderServiceBuilder
+where
+    Node: NodeBounds,
+    Pool: PoolBounds,
+{
+    async fn spawn_payload_builder_service(
+        self,
+        ctx: &BuilderContext<Node>,
+        pool: Pool,
+        _: OpEvmConfig,
+    ) -> eyre::Result<PayloadBuilderHandle<<Node::Types as NodeTypes>::Payload>> {
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let metrics = Arc::new(BuilderMetrics::default());
+        let task_metrics = Arc::new(FlashblocksTaskMetrics::new());
+        let ws_pub: Arc<WebSocketPublisher> = WebSocketPublisher::new(
+            self.config.flashblocks.ws_addr,
+            metrics.clone(),
+            &task_metrics.websocket_publisher,
+            self.config.flashblocks.ws_subscriber_limit,
+        )
+        .wrap_err("failed to create ws publisher for default builder")?
+        .into();
+
+        let mut broadcast_builder =
+            crate::broadcast::NodeBuilder::new(ws_pub.clone(), metrics.clone());
+
+        if let Some(ref private_key_file) = self.config.flashblocks.p2p_private_key_file
+            && !private_key_file.is_empty()
+        {
+            let private_key_hex = std::fs::read_to_string(private_key_file)
+                .wrap_err_with(|| {
+                    format!("failed to read p2p private key file: {private_key_file}")
+                })?
+                .trim()
+                .to_string();
+            broadcast_builder = broadcast_builder.with_keypair_hex_string(private_key_hex);
+        }
+
+        let known_peers: Vec<crate::broadcast::Multiaddr> =
+            if let Some(ref p2p_known_peers) = self.config.flashblocks.p2p_known_peers {
+                p2p_known_peers
+                    .split(',')
+                    .map(|s| s.to_string())
+                    .filter_map(|s| s.parse().ok())
+                    .collect()
+            } else {
+                vec![]
+            };
+
+        let crate::broadcast::NodeBuildResult {
+            node,
+            outgoing_message_tx: _,
+            mut incoming_message_rxs,
+        } = broadcast_builder
+            .with_agent_version(AGENT_VERSION.to_string())
+            .with_protocol(FLASHBLOCKS_STREAM_PROTOCOL)
+            .with_known_peers(known_peers)
+            .with_port(self.config.flashblocks.p2p_port)
+            .with_cancellation_token(cancel.clone())
+            .with_max_peer_count(self.config.flashblocks.p2p_max_peer_count)
+            .try_build()
+            .wrap_err("failed to build flashblocks p2p node")?;
+        let multiaddrs = node.multiaddrs();
+        ctx.task_executor().spawn_task(async move {
+            if let Err(e) = node.run().await {
+                tracing::error!(error = %e, "p2p node exited");
+            }
+        });
+        tracing::info!(target: "payload_builder", multiaddrs = ?multiaddrs, "default p2p node started");
+
+        let incoming_message_rx = incoming_message_rxs
+            .remove(&FLASHBLOCKS_STREAM_PROTOCOL)
+            .expect("flashblocks p2p protocol must be found in receiver map");
+
+        let p2p_cache = if self.config.flashblocks.replay_from_persistence_file {
+            FlashblockPayloadsCache::new(Some(ctx.config().datadir()))
+        } else {
+            FlashblockPayloadsCache::new(None)
+        };
+
+        let conf = ctx.config().builder.clone();
+        let default_builder = reth_optimism_payload_builder::OpPayloadBuilder::with_builder_config(
+            pool,
+            ctx.provider().clone(),
+            OpEvmConfig::optimism(ctx.chain_spec()),
+            OpBuilderConfig { da_config: self.da_config, gas_limit_config: self.gas_limit_config },
+        )
+        .set_compute_pending_block(self.compute_pending_block);
+        let payload_builder = DefaultPayloadBuilder::new(default_builder, p2p_cache.clone());
+        let payload_job_config = BasicPayloadJobGeneratorConfig::default()
+            .interval(conf.interval)
+            .deadline(conf.deadline)
+            .max_payload_tasks(conf.max_payload_tasks);
+
+        let payload_generator = BasicPayloadJobGenerator::with_builder(
+            ctx.provider().clone(),
+            ctx.task_executor().clone(),
+            payload_job_config,
+            payload_builder,
+        );
+        let (payload_service, payload_builder_handle) =
+            PayloadBuilderService::new(payload_generator, ctx.provider().canonical_state_stream());
+
+        let payload_handler =
+            DefaultPayloadHandler::new(incoming_message_rx, p2p_cache, ws_pub, cancel);
+
+        ctx.task_executor()
+            .spawn_critical_task("default payload builder service", Box::pin(payload_service));
+        ctx.task_executor().spawn_critical_task(
+            "default builder payload handler",
+            Box::pin(payload_handler.run()),
+        );
+
+        tracing::info!(target: "payload_builder", "Default payload builder service started");
+        Ok(payload_builder_handle)
+    }
+}

--- a/crates/builder/src/flashblocks/builder.rs
+++ b/crates/builder/src/flashblocks/builder.rs
@@ -279,7 +279,7 @@ where
     Client: ClientBounds,
     Tasks: TaskSpawner + Clone + Unpin + 'static,
 {
-    fn get_op_payload_builder_ctx(
+    fn get_flashblocks_payload_builder_ctx(
         &self,
         config: reth_basic_payload_builder::PayloadConfig<
             OpPayloadBuilderAttributes<op_alloy_consensus::OpTxEnvelope>,
@@ -352,7 +352,7 @@ where
 
         let disable_state_root = self.config.flashblocks.disable_state_root;
         let ctx = self
-            .get_op_payload_builder_ctx(config.clone(), block_cancel.clone())
+            .get_flashblocks_payload_builder_ctx(config.clone(), block_cancel.clone())
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
         // Initialize flashblocks state for this block
@@ -523,7 +523,7 @@ where
 
         let fb_cancel = block_cancel.child_token();
         let mut ctx = self
-            .get_op_payload_builder_ctx(config, fb_cancel.clone())
+            .get_flashblocks_payload_builder_ctx(config, fb_cancel.clone())
             .map_err(|e| PayloadBuilderError::Other(e.into()))?;
 
         // Create best_transaction iterator

--- a/crates/builder/src/flashblocks/handler.rs
+++ b/crates/builder/src/flashblocks/handler.rs
@@ -185,9 +185,8 @@ where
                             }));
                         }
                         Message::OpFlashblockPayload(fb_payload) => {
-                            if let XLayerFlashblockMessage::Payload(payload) = &fb_payload &&
-                                let Err(e) = p2p_cache.add_flashblock_payload(payload.inner.clone()) {
-                                warn!(target: "payload_builder", e = ?e, "failed to add flashblock txs to cache");
+                            if let XLayerFlashblockMessage::Payload(payload) = &fb_payload {
+                                p2p_cache.add_flashblock_payload(payload.inner.clone());
                             }
                             if let Err(e) = ws_pub.publish(&fb_payload) {
                                 warn!(target: "payload_builder", e = ?e, "failed to publish flashblock to websocket publisher");

--- a/crates/builder/src/flashblocks/utils/cache.rs
+++ b/crates/builder/src/flashblocks/utils/cache.rs
@@ -90,7 +90,7 @@ impl FlashblockPayloadsCache {
         }
     }
 
-    pub fn add_flashblock_payload(&self, payload: OpFlashblockPayload) -> eyre::Result<()> {
+    pub fn add_flashblock_payload(&self, payload: OpFlashblockPayload) {
         let mut guard = self.inner.lock();
         match guard.as_mut() {
             Some(sequence) if sequence.payload_id == payload.payload_id => {
@@ -110,7 +110,6 @@ impl FlashblockPayloadsCache {
                 });
             }
         }
-        Ok(())
     }
 
     pub async fn persist(&self) -> eyre::Result<()> {
@@ -259,7 +258,7 @@ mod tests {
         let parent = B256::random();
         let payload = make_payload([1u8; 8], 0, Some(parent), 100);
 
-        cache.add_flashblock_payload(payload).unwrap();
+        cache.add_flashblock_payload(payload);
 
         let guard = cache.inner.lock();
         let seq = guard.as_ref().unwrap();
@@ -275,11 +274,11 @@ mod tests {
         let id = [1u8; 8];
 
         // First payload (base, index 0)
-        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 100));
         // Second payload (incremental, index 1)
-        cache.add_flashblock_payload(make_payload(id, 1, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 1, None, 100));
         // Third payload (incremental, index 2)
-        cache.add_flashblock_payload(make_payload(id, 2, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 2, None, 100));
 
         let guard = cache.inner.lock();
         let seq = guard.as_ref().unwrap();
@@ -297,11 +296,11 @@ mod tests {
         let parent_b = B256::random();
 
         // Add payloads for first block
-        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent_a), 100)).unwrap();
-        cache.add_flashblock_payload(make_payload([1u8; 8], 1, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent_a), 100));
+        cache.add_flashblock_payload(make_payload([1u8; 8], 1, None, 100));
 
         // New payload_id replaces the entire cache
-        cache.add_flashblock_payload(make_payload([2u8; 8], 0, Some(parent_b), 101)).unwrap();
+        cache.add_flashblock_payload(make_payload([2u8; 8], 0, Some(parent_b), 101));
 
         let guard = cache.inner.lock();
         let seq = guard.as_ref().unwrap();
@@ -317,7 +316,7 @@ mod tests {
         let id = [1u8; 8];
 
         // First payload without base (no parent_hash)
-        cache.add_flashblock_payload(make_payload(id, 1, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 1, None, 100));
 
         {
             let guard = cache.inner.lock();
@@ -325,7 +324,7 @@ mod tests {
         }
 
         // Second payload with base containing parent_hash - should backfill
-        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 100));
 
         let guard = cache.inner.lock();
         assert_eq!(guard.as_ref().unwrap().parent_hash, Some(parent));
@@ -339,10 +338,10 @@ mod tests {
         let id = [1u8; 8];
 
         // First payload sets parent_hash
-        cache.add_flashblock_payload(make_payload(id, 0, Some(parent_first), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 0, Some(parent_first), 100));
 
         // Second payload with different parent_hash in base - should NOT overwrite
-        cache.add_flashblock_payload(make_payload(id, 1, Some(parent_second), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 1, Some(parent_second), 100));
 
         let guard = cache.inner.lock();
         assert_eq!(guard.as_ref().unwrap().parent_hash, Some(parent_first));
@@ -397,9 +396,9 @@ mod tests {
         let parent = B256::random();
         let id = [10u8; 8];
 
-        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 200)).unwrap();
-        cache.add_flashblock_payload(make_payload(id, 1, None, 200)).unwrap();
-        cache.add_flashblock_payload(make_payload(id, 2, None, 200)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 200));
+        cache.add_flashblock_payload(make_payload(id, 1, None, 200));
+        cache.add_flashblock_payload(make_payload(id, 2, None, 200));
 
         // Persist to disk
         cache.persist().await.unwrap();
@@ -426,7 +425,7 @@ mod tests {
     #[tokio::test]
     async fn persist_no_path_is_noop() {
         let cache = FlashblockPayloadsCache::default();
-        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(B256::ZERO), 1)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(B256::ZERO), 1));
 
         // Should succeed without writing anything (no persist_path)
         cache.persist().await.unwrap();
@@ -453,12 +452,12 @@ mod tests {
 
         // First sequence
         let parent_a = B256::random();
-        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent_a), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent_a), 100));
         cache.persist().await.unwrap();
 
         // Replace with second sequence
         let parent_b = B256::random();
-        cache.add_flashblock_payload(make_payload([2u8; 8], 0, Some(parent_b), 101)).unwrap();
+        cache.add_flashblock_payload(make_payload([2u8; 8], 0, Some(parent_b), 101));
         cache.persist().await.unwrap();
 
         // Loaded data should reflect the second sequence
@@ -491,7 +490,7 @@ mod tests {
 
         let cache = FlashblockPayloadsCache::with_persist_path(file_path.clone());
         let parent = B256::random();
-        cache.add_flashblock_payload(make_payload([5u8; 8], 0, Some(parent), 42)).unwrap();
+        cache.add_flashblock_payload(make_payload([5u8; 8], 0, Some(parent), 42));
         cache.persist().await.unwrap();
 
         // Read raw bytes and verify it's valid JSON that deserializes correctly
@@ -515,7 +514,7 @@ mod tests {
         let parent = B256::random();
         let wrong_parent = B256::random();
 
-        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent), 100));
 
         let result = cache.get_flashblocks_sequence_txs::<OpTransactionSigned>(wrong_parent);
         assert!(result.is_none());
@@ -527,7 +526,7 @@ mod tests {
         let parent = B256::random();
 
         // Only index 0 (base) — no flashblock transactions to return
-        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(parent), 100));
 
         let result = cache.get_flashblocks_sequence_txs::<OpTransactionSigned>(parent);
         assert_eq!(result, Some(vec![]));
@@ -538,7 +537,7 @@ mod tests {
         let cache = FlashblockPayloadsCache::default();
 
         // Payload without base (parent_hash will be None)
-        cache.add_flashblock_payload(make_payload([1u8; 8], 1, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 1, None, 100));
 
         // Any query should return None since cached parent_hash is None
         let result = cache.get_flashblocks_sequence_txs::<OpTransactionSigned>(B256::ZERO);
@@ -552,11 +551,11 @@ mod tests {
         let id = [1u8; 8];
 
         // index 0 (base)
-        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 0, Some(parent), 100));
         // index 1 — sequential
-        cache.add_flashblock_payload(make_payload(id, 1, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 1, None, 100));
         // index 3 — gap (skipped index 2)
-        cache.add_flashblock_payload(make_payload(id, 3, None, 100)).unwrap();
+        cache.add_flashblock_payload(make_payload(id, 3, None, 100));
 
         let result = cache.get_flashblocks_sequence_txs::<OpTransactionSigned>(parent);
         assert!(result.is_none(), "gap in indexes should return None");
@@ -572,7 +571,7 @@ mod tests {
         // Spawn writer thread
         let writer = std::thread::spawn(move || {
             for i in 0..100u64 {
-                cache_clone.add_flashblock_payload(make_payload(id, i, Some(parent), 100)).unwrap();
+                cache_clone.add_flashblock_payload(make_payload(id, i, Some(parent), 100));
             }
         });
 
@@ -598,7 +597,7 @@ mod tests {
         let cache = FlashblockPayloadsCache::default();
         let clone = cache.clone();
 
-        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(B256::ZERO), 1)).unwrap();
+        cache.add_flashblock_payload(make_payload([1u8; 8], 0, Some(B256::ZERO), 1));
 
         // Clone should see the same data
         let guard = clone.inner.lock();

--- a/crates/builder/src/lib.rs
+++ b/crates/builder/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod broadcast;
+pub mod default;
 pub mod flashblocks;
 pub mod metrics;
 pub(crate) mod signer;

--- a/crates/flashblocks/src/persist.rs
+++ b/crates/flashblocks/src/persist.rs
@@ -22,12 +22,8 @@ pub async fn handle_persistence(mut rx: ReceivedFlashblocksRx, datadir: ChainPat
             result = rx.recv() => {
                 match result {
                     Ok(fb_payload) => {
-                        if let XLayerFlashblockMessage::Payload(payload) = &*fb_payload
-                            && let Err(e) =
-                                cache.add_flashblock_payload(payload.inner.clone())
-                        {
-                            warn!(target: "flashblocks", "Failed to cache flashblock payload: {e}");
-                            continue;
+                        if let XLayerFlashblockMessage::Payload(payload) = &*fb_payload {
+                            cache.add_flashblock_payload(payload.inner.clone());
                         }
                         dirty = true;
                     }


### PR DESCRIPTION
## Summary

Adds P2P reorg protection to the default OP builder (when `flashblocks.enabled=false`) via a wrapper pattern that fully preserves the upstream `OpPayloadBuilder`. On conductor-driven failover, the new leader replays cached flashblocks transactions to avoid reorgs for RPC subscribers.

## Architecture

```
┌─────────────────────────────────────────────────────────┐
│ DefaultBuilderServiceBuilder (PayloadServiceBuilder)    │
│                                                         │
│  ┌──────────────┐    ┌──────────────────────────────┐   │
│  │ P2P Node     │───▶│ DefaultPayloadHandler        │   │
│  │ (libp2p)     │    │  • routes OpFlashblockPayload │   │
│  │ /flashblocks │    │    to cache                   │   │
│  │  /2.0.0      │    │  • relays to WS subscribers   │   │
│  └──────────────┘    └──────────┬───────────────────┘   │
│                                 │                       │
│                    ┌────────────▼────────────┐          │
│                    │ FlashblockPayloadsCache │          │
│                    │  (shared, Arc<Mutex>)   │          │
│                    │  • optional disk persist│          │
│                    └────────────┬────────────┘          │
│                                 │                       │
│  ┌──────────────────────────────▼───────────────────┐   │
│  │ DefaultPayloadBuilder (PayloadBuilder trait)     │   │
│  │                                                  │   │
│  │  try_build(args):                                │   │
│  │    1. cache.get_sequence_txs(parent_hash)        │   │
│  │    2. cache hit  → build_with_cached_txs()       │   │
│  │       cache miss → inner.try_build(args)         │   │
│  │                                                  │   │
│  │  ┌────────────────────────────────────────────┐  │   │
│  │  │ inner: OpPayloadBuilder (fully preserved)  │  │   │
│  │  └────────────────────────────────────────────┘  │   │
│  └──────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────┘
```

**Cache replay path** (`build_with_cached_txs`): replicates `OpBuilder::build` flow — constructs `OpPayloadBuilderCtx`, applies pre-execution changes, executes sequencer txs, then replays cached txs via `BlockBuilder::execute_transaction` instead of pulling from the tx pool. Finalization uses the same `builder.finish()` for state root, receipt root, and block assembly.

**Error handling**: mirrors the flashblocks builder — `execute_cached_transactions` returns `Err` on any failure (DA limits, blob/deposit rejection, EVM errors), caller discards and resolves payload with whatever was successfully executed.

## Changes

- **`crates/builder/src/default/`** — new module:
  - `builder.rs`: `DefaultPayloadBuilder` wrapping `OpPayloadBuilder` + `FlashblockPayloadsCache`
  - `service.rs`: `DefaultBuilderServiceBuilder` wiring P2P, cache, handler, and wrapped builder
  - `handler.rs`: `DefaultPayloadHandler` routing P2P messages to cache + WS relay
- **`bin/node/src/payload.rs`** — `XLayerPayloadServiceBuilder` always uses `DefaultBuilderServiceBuilder` when `flashblocks.enabled=false` (reads same `BuilderConfig`)
- **Reused**: `FlashblockPayloadsCache`, `broadcast::NodeBuilder`, `WebSocketPublisher` — zero duplication