### PR TITLE
chore(builder): Fix builder p2p warning logs on disconnection with peers

### DIFF
--- a/crates/builder/src/broadcast/mod.rs
+++ b/crates/builder/src/broadcast/mod.rs
@@ -538,8 +538,8 @@ impl IncomingStreamsHandler {
                 }
                 Some(res) = handle_stream_futures.next() => {
                     match res {
-                        Ok(Ok(())) => {
-                            warn!(target: "payload_builder::broadcast", "incoming stream closed on protocol {protocol}");
+                        Ok(Ok(peer_id)) => {
+                            warn!(target: "payload_builder::broadcast", "incoming stream closed with peer {peer_id} on protocol {protocol}");
                         }
                         Ok(Err(e)) => {
                             warn!(target: "payload_builder::broadcast", "error handling incoming stream: {e:?}");
@@ -558,7 +558,7 @@ async fn handle_incoming_stream(
     peer_id: PeerId,
     stream: Stream,
     payload_tx: mpsc::Sender<Message>,
-) -> eyre::Result<()> {
+) -> eyre::Result<PeerId> {
     use futures::StreamExt as _;
     use tokio_util::{
         codec::{FramedRead, LinesCodec},
@@ -582,7 +582,7 @@ async fn handle_incoming_stream(
         }
     }
 
-    Ok(())
+    Ok(peer_id)
 }
 
 fn create_transport(

--- a/crates/builder/src/broadcast/mod.rs
+++ b/crates/builder/src/broadcast/mod.rs
@@ -300,7 +300,7 @@ impl Node {
                             cause,
                             ..
                         } => {
-                            debug!(target: "payload_builder::broadcast", "connection closed with peer {peer_id}: {cause:?}");
+                            warn!(target: "payload_builder::broadcast", "connection closed with peer {peer_id}: {cause:?}");
                             outgoing_streams_handler.remove_peer(&peer_id);
                         }
                         SwarmEvent::Behaviour(event) => event.handle(&mut swarm),
@@ -538,7 +538,9 @@ impl IncomingStreamsHandler {
                 }
                 Some(res) = handle_stream_futures.next() => {
                     match res {
-                        Ok(Ok(())) => {}
+                        Ok(Ok(())) => {
+                            warn!(target: "payload_builder::broadcast", "incoming stream closed on protocol {protocol}");
+                        }
                         Ok(Err(e)) => {
                             warn!(target: "payload_builder::broadcast", "error handling incoming stream: {e:?}");
                         }


### PR DESCRIPTION
## Summary

- Upgrade `SwarmEvent::ConnectionClosed` logging from `debug!` to `warn!` so TCP-level peer disconnections are visible at production log levels
- Add `warn!` log for clean incoming yamux stream closures (previously silent), which indicate peer stream drops on the long-lived `/flashblocks/2.0.0` protocol

## Test plan

- [x] `cargo clippy -p xlayer-builder --all-targets -- -D warnings` passes
- [x] All 11 broadcast module tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)