### PR TITLE
feat(rpc): add eth_flashblocksPeerStatus API for P2P peer visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14404,6 +14404,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "xlayer-builder",
  "xlayer-flashblocks",
 ]
 

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -271,7 +271,11 @@ fn main() {
                     };
 
                     // Register X Layer RPC
-                    let xlayer_rpc = DefaultRpcExt::new(flashblocks_state, fb_p2p_status.get().cloned());
+                    let peer_status = fb_p2p_status.get().cloned();
+                    if xlayer_args.sequencer_mode && peer_status.is_none() {
+                        tracing::warn!(target: "reth::cli", "fb_p2p_status not initialized — eth_flashblocksPeerStatus will return null on sequencer");
+                    }
+                    let xlayer_rpc = DefaultRpcExt::new(flashblocks_state, peer_status);
                     ctx.modules
                         .merge_configured(DefaultRpcExtApiServer::into_rpc(xlayer_rpc))?;
                     info!(target: "reth::cli", "xlayer eth rpc extension enabled");

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -131,10 +131,12 @@ fn main() {
 
             // Create the X Layer payload service builder
             // It handles both flashblocks and default modes internally
+            let fb_p2p_status = Arc::new(OnceLock::new());
             let payload_builder = XLayerPayloadServiceBuilder::new(
                 args.xlayer_args.builder.clone(),
                 args.rollup_args.compute_pending_block,
                 xlayer_args.sequencer_mode,
+                fb_p2p_status.clone(),
             )?
             .with_bridge_config(bridge_config);
 
@@ -269,7 +271,7 @@ fn main() {
                     };
 
                     // Register X Layer RPC
-                    let xlayer_rpc = DefaultRpcExt::new(flashblocks_state);
+                    let xlayer_rpc = DefaultRpcExt::new(flashblocks_state, fb_p2p_status.get().cloned());
                     ctx.modules
                         .merge_configured(DefaultRpcExtApiServer::into_rpc(xlayer_rpc))?;
                     info!(target: "reth::cli", "xlayer eth rpc extension enabled");

--- a/bin/node/src/payload.rs
+++ b/bin/node/src/payload.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, OnceLock};
+
 use reth::builder::components::PayloadServiceBuilder;
 use reth_node_api::NodeTypes;
 use reth_node_builder::{components::BasicPayloadServiceBuilder, BuilderContext};
@@ -7,6 +9,7 @@ use reth_optimism_payload_builder::config::{OpDAConfig, OpGasLimitConfig};
 use xlayer_bridge_intercept::BridgeInterceptConfig;
 use xlayer_builder::{
     args::BuilderArgs,
+    broadcast::PeerStatusTracker,
     default::DefaultBuilderServiceBuilder,
     flashblocks::{BuilderConfig, FlashblocksServiceBuilder},
     traits::{NodeBounds, PoolBounds},
@@ -34,11 +37,13 @@ impl XLayerPayloadServiceBuilder {
         xlayer_builder_args: BuilderArgs,
         compute_pending_block: bool,
         sequencer_mode: bool,
+        peer_status: Arc<OnceLock<PeerStatusTracker>>,
     ) -> eyre::Result<Self> {
         Self::with_config(
             xlayer_builder_args,
             compute_pending_block,
             sequencer_mode,
+            peer_status,
             OpDAConfig::default(),
             OpGasLimitConfig::default(),
         )
@@ -48,6 +53,7 @@ impl XLayerPayloadServiceBuilder {
         xlayer_builder_args: BuilderArgs,
         compute_pending_block: bool,
         sequencer_mode: bool,
+        peer_status: Arc<OnceLock<PeerStatusTracker>>,
         da_config: OpDAConfig,
         gas_limit_config: OpGasLimitConfig,
     ) -> eyre::Result<Self> {
@@ -58,6 +64,7 @@ impl XLayerPayloadServiceBuilder {
                 XLayerPayloadServiceBuilderInner::Flashblocks(Box::new(FlashblocksServiceBuilder {
                     config,
                     bridge_intercept: Default::default(),
+                    peer_status_sink: peer_status.clone(),
                 }))
             } else {
                 XLayerPayloadServiceBuilderInner::DefaultWithP2P(Box::new(
@@ -66,6 +73,7 @@ impl XLayerPayloadServiceBuilder {
                         config,
                         da_config,
                         gas_limit_config,
+                        peer_status_sink: peer_status.clone(),
                     },
                 ))
             }

--- a/crates/builder/src/broadcast/mod.rs
+++ b/crates/builder/src/broadcast/mod.rs
@@ -1,12 +1,14 @@
 mod behaviour;
 mod outgoing;
 pub(crate) mod payload;
+pub mod peer_status;
 pub(crate) mod types;
 pub(crate) mod wspub;
 
 use behaviour::Behaviour;
 pub use libp2p::{Multiaddr, StreamProtocol};
 pub use payload::{XLayerFlashblockEnd, XLayerFlashblockMessage, XLayerFlashblockPayload};
+pub use peer_status::PeerStatusTracker;
 pub use types::Message;
 pub use wspub::WebSocketPublisher;
 
@@ -121,6 +123,9 @@ pub struct Node {
 
     /// The metrics for the builder
     metrics: Arc<BuilderMetrics>,
+
+    /// Shared peer status tracker for RPC visibility.
+    peer_status: PeerStatusTracker,
 }
 
 impl Node {
@@ -153,6 +158,7 @@ impl Node {
             protocols,
             ws_pub,
             metrics,
+            peer_status,
         } = self;
 
         for addr in listen_addrs {
@@ -174,6 +180,8 @@ impl Node {
             swarm.dial(address.clone()).wrap_err("swarm failed to dial known peer")?;
             known_peers_info.push((peer_id, address));
         }
+
+        peer_status.register_static_peers(&known_peers_info);
 
         let handles = incoming_streams_handlers
             .into_iter()
@@ -214,6 +222,7 @@ impl Node {
                     match result {
                         Ok(stream) => {
                             outgoing_streams_handler.insert_peer_and_stream(peer_id, protocol.clone(), stream);
+                            peer_status.on_stream_opened(peer_id);
                             debug!(target: "payload_builder::broadcast", "opened outbound stream with peer {peer_id} on protocol {protocol}");
                         }
                         Err(e) => {
@@ -242,9 +251,7 @@ impl Node {
                     // in the gossiping of new flashblock payloads to websocket subscribers.
                     match outgoing_streams_handler.broadcast_message(message.clone()).await {
                         Ok(failed_peers) => {
-                            // `broadcast_message` already removed failed peers from
-                            // `peers_to_stream`, so no `has_peer` guard is needed here.
-                            // Push open_stream futures to recover the yamux streams.
+                            peer_status.on_broadcast_result(&failed_peers);
                             for &peer_id in &failed_peers {
                                 for proto in &protocols {
                                     pending_streams.push(peer_id, proto.clone(), swarm.behaviour_mut().new_control());
@@ -289,6 +296,7 @@ impl Node {
                             // when a new connection is established, open outbound streams for each protocol
                             // and add them to the outgoing streams handler.
                             debug!(target: "payload_builder::broadcast", "fb p2p connection established with peer {peer_id} on connection {connection_id}");
+                            peer_status.on_connected(peer_id, None);
                             if !outgoing_streams_handler.has_peer(&peer_id) {
                                 for protocol in &protocols {
                                     pending_streams.push(peer_id, protocol.clone(), swarm.behaviour_mut().new_control());
@@ -302,6 +310,7 @@ impl Node {
                         } => {
                             debug!(target: "payload_builder::broadcast", "connection closed with peer {peer_id}: {cause:?}");
                             outgoing_streams_handler.remove_peer(&peer_id);
+                            peer_status.on_disconnected(peer_id);
                         }
                         SwarmEvent::Behaviour(event) => event.handle(&mut swarm),
                         _ => continue,
@@ -316,6 +325,9 @@ pub struct NodeBuildResult {
     pub node: Node,
     pub outgoing_message_tx: mpsc::Sender<Message>,
     pub incoming_message_rxs: HashMap<StreamProtocol, mpsc::Receiver<Message>>,
+    /// Shared peer status tracker — clone into the RPC layer for
+    /// `eth_flashblocksPeerStatus`.
+    pub peer_status: PeerStatusTracker,
 }
 
 pub struct NodeBuilder {
@@ -482,6 +494,8 @@ impl NodeBuilder {
 
         let (outgoing_message_tx, outgoing_message_rx) = tokio::sync::mpsc::channel(100);
 
+        let peer_status = PeerStatusTracker::new(peer_id);
+
         Ok(NodeBuildResult {
             node: Node {
                 peer_id,
@@ -495,9 +509,11 @@ impl NodeBuilder {
                 protocols,
                 ws_pub,
                 metrics,
+                peer_status: peer_status.clone(),
             },
             outgoing_message_tx,
             incoming_message_rxs,
+            peer_status,
         })
     }
 }
@@ -652,14 +668,18 @@ mod test {
         drop(_guard1);
         drop(_guard2);
 
-        let NodeBuildResult { node: node1, outgoing_message_tx: _, incoming_message_rxs: mut rx1 } =
-            make_test_node_builder()
-                .with_listen_addr(format!("/ip4/127.0.0.1/tcp/{port1}").parse().unwrap())
-                .with_agent_version(TEST_AGENT_VERSION.to_string())
-                .with_protocol(types::FLASHBLOCKS_STREAM_PROTOCOL)
-                .try_build()
-                .unwrap();
-        let NodeBuildResult { node: node2, outgoing_message_tx: tx2, incoming_message_rxs: _ } =
+        let NodeBuildResult {
+            node: node1,
+            outgoing_message_tx: _,
+            incoming_message_rxs: mut rx1,
+            ..
+        } = make_test_node_builder()
+            .with_listen_addr(format!("/ip4/127.0.0.1/tcp/{port1}").parse().unwrap())
+            .with_agent_version(TEST_AGENT_VERSION.to_string())
+            .with_protocol(types::FLASHBLOCKS_STREAM_PROTOCOL)
+            .try_build()
+            .unwrap();
+        let NodeBuildResult { node: node2, outgoing_message_tx: tx2, .. } =
             make_test_node_builder()
                 .with_known_peers(node1.multiaddrs())
                 .with_protocol(types::FLASHBLOCKS_STREAM_PROTOCOL)

--- a/crates/builder/src/broadcast/peer_status.rs
+++ b/crates/builder/src/broadcast/peer_status.rs
@@ -37,6 +37,15 @@ enum PeerConnectionState {
     NeverConnected,
 }
 
+/// Serializable connection state for the RPC response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionState {
+    Connected,
+    Disconnected,
+    NeverConnected,
+}
+
 impl PeerStatusTracker {
     /// Creates a new tracker for the given local peer.
     pub fn new(local_peer_id: PeerId) -> Self {
@@ -70,9 +79,16 @@ impl PeerStatusTracker {
     }
 
     /// The TCP connection with `peer_id` was closed.
+    ///
+    /// Non-static peers are removed entirely on disconnect to prevent unbounded
+    /// accumulation from transient mDNS/DHT connections.
     pub fn on_disconnected(&self, peer_id: PeerId) {
         let mut inner = self.inner.write();
         if let Some(entry) = inner.peers.get_mut(&peer_id) {
+            if !entry.is_static {
+                inner.peers.remove(&peer_id);
+                return;
+            }
             entry.state = PeerConnectionState::Disconnected { since: Instant::now() };
             entry.has_stream = false;
         }
@@ -115,13 +131,19 @@ impl PeerStatusTracker {
             .map(|(peer_id, entry)| {
                 let (connection_state, connected_duration_secs, disconnected_duration_secs) =
                     match &entry.state {
-                        PeerConnectionState::Connected { since } => {
-                            ("connected", Some(now.duration_since(*since).as_secs_f64()), None)
+                        PeerConnectionState::Connected { since } => (
+                            ConnectionState::Connected,
+                            Some(now.duration_since(*since).as_secs_f64()),
+                            None,
+                        ),
+                        PeerConnectionState::Disconnected { since } => (
+                            ConnectionState::Disconnected,
+                            None,
+                            Some(now.duration_since(*since).as_secs_f64()),
+                        ),
+                        PeerConnectionState::NeverConnected => {
+                            (ConnectionState::NeverConnected, None, None)
                         }
-                        PeerConnectionState::Disconnected { since } => {
-                            ("disconnected", None, Some(now.duration_since(*since).as_secs_f64()))
-                        }
-                        PeerConnectionState::NeverConnected => ("never_connected", None, None),
                     };
 
                 let last_broadcast_secs_ago =
@@ -131,7 +153,7 @@ impl PeerStatusTracker {
                     peer_id: peer_id.to_string(),
                     multiaddr: entry.multiaddr.as_ref().map(|a| a.to_string()),
                     is_static: entry.is_static,
-                    connection_state: connection_state.to_string(),
+                    connection_state,
                     has_stream: entry.has_stream,
                     connected_duration_secs,
                     disconnected_duration_secs,
@@ -144,10 +166,12 @@ impl PeerStatusTracker {
         // Sort: static first, then by peer_id for deterministic output.
         peers.sort_by(|a, b| b.is_static.cmp(&a.is_static).then_with(|| a.peer_id.cmp(&b.peer_id)));
 
-        let connected = peers.iter().filter(|p| p.connection_state == "connected").count();
-        let disconnected = peers.iter().filter(|p| p.connection_state == "disconnected").count();
+        let connected =
+            peers.iter().filter(|p| p.connection_state == ConnectionState::Connected).count();
+        let disconnected =
+            peers.iter().filter(|p| p.connection_state == ConnectionState::Disconnected).count();
         let never_connected =
-            peers.iter().filter(|p| p.connection_state == "never_connected").count();
+            peers.iter().filter(|p| p.connection_state == ConnectionState::NeverConnected).count();
         let static_peers = peers.iter().filter(|p| p.is_static).count();
 
         PeerStatusSnapshot {
@@ -195,8 +219,7 @@ pub struct PeerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiaddr: Option<String>,
     pub is_static: bool,
-    /// One of `"connected"`, `"disconnected"`, `"never_connected"`.
-    pub connection_state: String,
+    pub connection_state: ConnectionState,
     pub has_stream: bool,
     /// Seconds since connection was established (present only when connected).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -239,7 +262,7 @@ mod tests {
         assert_eq!(snap.summary.total, 1);
         assert_eq!(snap.summary.never_connected, 1);
         assert_eq!(snap.summary.static_peers, 1);
-        assert_eq!(snap.peers[0].connection_state, "never_connected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::NeverConnected);
         assert!(snap.peers[0].is_static);
         assert_eq!(snap.peers[0].connection_count, 0);
     }
@@ -257,25 +280,39 @@ mod tests {
         let snap = tracker.snapshot();
         assert_eq!(snap.summary.connected, 1);
         assert_eq!(snap.summary.never_connected, 0);
-        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::Connected);
         assert_eq!(snap.peers[0].connection_count, 1);
         assert!(snap.peers[0].connected_duration_secs.is_some());
     }
 
     #[test]
-    fn disconnect_clears_stream_and_records_duration() {
+    fn disconnect_static_peer_clears_stream_and_records_duration() {
         let local = test_peer_id(0);
         let tracker = PeerStatusTracker::new(local);
 
         let peer_a = test_peer_id(1);
+        tracker.register_static_peers(&[(peer_a, test_multiaddr(9001))]);
         tracker.on_connected(peer_a, None);
         tracker.on_stream_opened(peer_a);
 
         tracker.on_disconnected(peer_a);
         let snap = tracker.snapshot();
-        assert_eq!(snap.peers[0].connection_state, "disconnected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::Disconnected);
         assert!(!snap.peers[0].has_stream);
         assert!(snap.peers[0].disconnected_duration_secs.is_some());
+    }
+
+    #[test]
+    fn disconnect_non_static_peer_removes_entry() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        tracker.on_connected(peer_a, None);
+        assert_eq!(tracker.snapshot().summary.total, 1);
+
+        tracker.on_disconnected(peer_a);
+        assert_eq!(tracker.snapshot().summary.total, 0);
     }
 
     #[test]
@@ -284,30 +321,30 @@ mod tests {
         let tracker = PeerStatusTracker::new(local);
 
         let peer_a = test_peer_id(1);
+        tracker.register_static_peers(&[(peer_a, test_multiaddr(9001))]);
         tracker.on_connected(peer_a, None);
         tracker.on_disconnected(peer_a);
         tracker.on_connected(peer_a, None);
 
         let snap = tracker.snapshot();
-        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::Connected);
         assert_eq!(snap.peers[0].connection_count, 2);
         assert!(snap.peers[0].disconnected_duration_secs.is_none());
     }
 
     #[test]
-    fn non_static_peer_tracked_on_connect() {
+    fn non_static_peer_tracked_while_connected() {
         let local = test_peer_id(0);
         let tracker = PeerStatusTracker::new(local);
 
         let peer_b = test_peer_id(2);
-        let addr_b = test_multiaddr(9002);
-        tracker.on_connected(peer_b, Some(addr_b));
+        tracker.on_connected(peer_b, Some(test_multiaddr(9002)));
 
         let snap = tracker.snapshot();
         assert_eq!(snap.summary.total, 1);
         assert_eq!(snap.summary.static_peers, 0);
         assert!(!snap.peers[0].is_static);
-        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::Connected);
     }
 
     #[test]
@@ -324,7 +361,7 @@ mod tests {
 
         let snap = tracker.snapshot();
         // Connection is still up, only stream is lost.
-        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::Connected);
         assert!(!snap.peers[0].has_stream);
         // Failed peer should not get last_broadcast_at updated.
         assert!(snap.peers[0].last_broadcast_secs_ago.is_none());
@@ -390,7 +427,7 @@ mod tests {
         tracker.register_static_peers(&[(peer_a, addr_a)]);
         let snap = tracker.snapshot();
         assert!(snap.peers[0].is_static);
-        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_state, ConnectionState::Connected);
         assert_eq!(snap.peers[0].connection_count, 1);
 
         // Connect with None multiaddr — should keep existing addr.

--- a/crates/builder/src/broadcast/peer_status.rs
+++ b/crates/builder/src/broadcast/peer_status.rs
@@ -263,28 +263,31 @@ mod tests {
     }
 
     #[test]
-    fn disconnect_then_reconnect() {
+    fn disconnect_clears_stream_and_records_duration() {
         let local = test_peer_id(0);
         let tracker = PeerStatusTracker::new(local);
 
         let peer_a = test_peer_id(1);
-        let addr_a = test_multiaddr(9001);
-        tracker.register_static_peers(&[(peer_a, addr_a.clone())]);
-
-        // Connect
-        tracker.on_connected(peer_a, Some(addr_a.clone()));
+        tracker.on_connected(peer_a, None);
         tracker.on_stream_opened(peer_a);
-        assert!(tracker.snapshot().peers[0].has_stream);
 
-        // Disconnect
         tracker.on_disconnected(peer_a);
         let snap = tracker.snapshot();
         assert_eq!(snap.peers[0].connection_state, "disconnected");
         assert!(!snap.peers[0].has_stream);
         assert!(snap.peers[0].disconnected_duration_secs.is_some());
+    }
 
-        // Reconnect
-        tracker.on_connected(peer_a, Some(addr_a));
+    #[test]
+    fn reconnect_increments_count_and_clears_disconnected_duration() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        tracker.on_connected(peer_a, None);
+        tracker.on_disconnected(peer_a);
+        tracker.on_connected(peer_a, None);
+
         let snap = tracker.snapshot();
         assert_eq!(snap.peers[0].connection_state, "connected");
         assert_eq!(snap.peers[0].connection_count, 2);
@@ -328,23 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn broadcast_success_updates_last_broadcast() {
-        let local = test_peer_id(0);
-        let tracker = PeerStatusTracker::new(local);
-
-        let peer_a = test_peer_id(1);
-        tracker.on_connected(peer_a, None);
-        tracker.on_stream_opened(peer_a);
-
-        assert!(tracker.snapshot().peers[0].last_broadcast_secs_ago.is_none());
-
-        tracker.on_broadcast_result(&[]);
-        let snap = tracker.snapshot();
-        assert!(snap.peers[0].last_broadcast_secs_ago.is_some());
-    }
-
-    #[test]
-    fn broadcast_result_only_updates_peers_with_stream() {
+    fn broadcast_success_only_updates_peers_with_stream() {
         let local = test_peer_id(0);
         let tracker = PeerStatusTracker::new(local);
 
@@ -353,7 +340,6 @@ mod tests {
         tracker.on_connected(peer_a, None);
         tracker.on_stream_opened(peer_a);
         tracker.on_connected(peer_b, None);
-        // peer_b has no stream
 
         tracker.on_broadcast_result(&[]);
         let snap = tracker.snapshot();
@@ -377,6 +363,39 @@ mod tests {
         let snap = tracker.snapshot();
         assert!(snap.peers[0].is_static);
         assert!(!snap.peers[1].is_static);
+    }
+
+    #[test]
+    fn unknown_peer_operations_are_noop() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+        let unknown = test_peer_id(99);
+
+        tracker.on_disconnected(unknown);
+        tracker.on_stream_opened(unknown);
+        tracker.on_broadcast_result(&[unknown]);
+        assert_eq!(tracker.snapshot().summary.total, 0);
+    }
+
+    #[test]
+    fn existing_peer_state_preserved_on_reregistration() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        let addr_a = test_multiaddr(9001);
+
+        // Connect first, then late static registration — should not clobber state.
+        tracker.on_connected(peer_a, Some(addr_a.clone()));
+        tracker.register_static_peers(&[(peer_a, addr_a)]);
+        let snap = tracker.snapshot();
+        assert!(snap.peers[0].is_static);
+        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_count, 1);
+
+        // Connect with None multiaddr — should keep existing addr.
+        tracker.on_connected(peer_a, None);
+        assert!(tracker.snapshot().peers[0].multiaddr.is_some());
     }
 
     #[test]

--- a/crates/builder/src/broadcast/peer_status.rs
+++ b/crates/builder/src/broadcast/peer_status.rs
@@ -1,0 +1,393 @@
+use libp2p::{Multiaddr, PeerId};
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+/// Shared peer status tracker.
+#[derive(Clone, Debug)]
+pub struct PeerStatusTracker {
+    inner: Arc<RwLock<PeerStatusInner>>,
+}
+
+#[derive(Debug)]
+struct PeerStatusInner {
+    local_peer_id: PeerId,
+    peers: HashMap<PeerId, PeerEntry>,
+}
+
+#[derive(Debug, Default)]
+struct PeerEntry {
+    multiaddr: Option<Multiaddr>,
+    is_static: bool,
+    state: PeerConnectionState,
+    has_stream: bool,
+    connection_count: u64,
+    last_broadcast_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+enum PeerConnectionState {
+    Connected {
+        since: Instant,
+    },
+    Disconnected {
+        since: Instant,
+    },
+    #[default]
+    NeverConnected,
+}
+
+impl PeerStatusTracker {
+    /// Creates a new tracker for the given local peer.
+    pub fn new(local_peer_id: PeerId) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(PeerStatusInner { local_peer_id, peers: HashMap::new() })),
+        }
+    }
+
+    /// Registers static (known) peers parsed from `--flashblocks.p2p_known_peers`.
+    ///
+    /// Called once at the start of [`super::Node::run`] after building
+    /// `known_peers_info`.
+    pub fn register_static_peers(&self, peers: &[(PeerId, Multiaddr)]) {
+        let mut inner = self.inner.write();
+        for (peer_id, addr) in peers {
+            let entry = inner.peers.entry(*peer_id).or_default();
+            entry.multiaddr = Some(addr.clone());
+            entry.is_static = true;
+        }
+    }
+
+    /// A TCP connection was established with `peer_id`.
+    pub fn on_connected(&self, peer_id: PeerId, multiaddr: Option<Multiaddr>) {
+        let mut inner = self.inner.write();
+        let entry = inner.peers.entry(peer_id).or_default();
+        entry.state = PeerConnectionState::Connected { since: Instant::now() };
+        entry.connection_count += 1;
+        if let Some(addr) = multiaddr {
+            entry.multiaddr = Some(addr);
+        }
+    }
+
+    /// The TCP connection with `peer_id` was closed.
+    pub fn on_disconnected(&self, peer_id: PeerId) {
+        let mut inner = self.inner.write();
+        if let Some(entry) = inner.peers.get_mut(&peer_id) {
+            entry.state = PeerConnectionState::Disconnected { since: Instant::now() };
+            entry.has_stream = false;
+        }
+    }
+
+    /// An application-level stream was successfully opened with `peer_id`.
+    pub fn on_stream_opened(&self, peer_id: PeerId) {
+        let mut inner = self.inner.write();
+        if let Some(entry) = inner.peers.get_mut(&peer_id) {
+            entry.has_stream = true;
+        }
+    }
+
+    /// Processes the result of a broadcast attempt. Marks failed peers as having
+    /// lost their stream, and updates `last_broadcast_at` for peers that
+    /// successfully received the message.
+    pub fn on_broadcast_result(&self, failed_peers: &[PeerId]) {
+        let now = Instant::now();
+        let mut inner = self.inner.write();
+        for &peer_id in failed_peers {
+            if let Some(entry) = inner.peers.get_mut(&peer_id) {
+                entry.has_stream = false;
+            }
+        }
+        for entry in inner.peers.values_mut() {
+            if entry.has_stream {
+                entry.last_broadcast_at = Some(now);
+            }
+        }
+    }
+
+    /// Returns a point-in-time snapshot of all peer statuses.
+    pub fn snapshot(&self) -> PeerStatusSnapshot {
+        let now = Instant::now();
+        let inner = self.inner.read();
+
+        let mut peers: Vec<PeerInfo> = inner
+            .peers
+            .iter()
+            .map(|(peer_id, entry)| {
+                let (connection_state, connected_duration_secs, disconnected_duration_secs) =
+                    match &entry.state {
+                        PeerConnectionState::Connected { since } => {
+                            ("connected", Some(now.duration_since(*since).as_secs_f64()), None)
+                        }
+                        PeerConnectionState::Disconnected { since } => {
+                            ("disconnected", None, Some(now.duration_since(*since).as_secs_f64()))
+                        }
+                        PeerConnectionState::NeverConnected => ("never_connected", None, None),
+                    };
+
+                let last_broadcast_secs_ago =
+                    entry.last_broadcast_at.map(|t| now.duration_since(t).as_secs_f64());
+
+                PeerInfo {
+                    peer_id: peer_id.to_string(),
+                    multiaddr: entry.multiaddr.as_ref().map(|a| a.to_string()),
+                    is_static: entry.is_static,
+                    connection_state: connection_state.to_string(),
+                    has_stream: entry.has_stream,
+                    connected_duration_secs,
+                    disconnected_duration_secs,
+                    connection_count: entry.connection_count,
+                    last_broadcast_secs_ago,
+                }
+            })
+            .collect();
+
+        // Sort: static first, then by peer_id for deterministic output.
+        peers.sort_by(|a, b| b.is_static.cmp(&a.is_static).then_with(|| a.peer_id.cmp(&b.peer_id)));
+
+        let connected = peers.iter().filter(|p| p.connection_state == "connected").count();
+        let disconnected = peers.iter().filter(|p| p.connection_state == "disconnected").count();
+        let never_connected =
+            peers.iter().filter(|p| p.connection_state == "never_connected").count();
+        let static_peers = peers.iter().filter(|p| p.is_static).count();
+
+        PeerStatusSnapshot {
+            local_peer_id: inner.local_peer_id.to_string(),
+            summary: PeerSummary {
+                total: peers.len(),
+                connected,
+                disconnected,
+                never_connected,
+                static_peers,
+            },
+            peers,
+        }
+    }
+}
+
+/// Top-level response for `eth_flashblocksPeerStatus`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerStatusSnapshot {
+    /// The local libp2p peer ID of this node.
+    pub local_peer_id: String,
+    /// Aggregate counts.
+    pub summary: PeerSummary,
+    /// Per-peer details.
+    pub peers: Vec<PeerInfo>,
+}
+
+/// Summary statistics.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerSummary {
+    pub total: usize,
+    pub connected: usize,
+    pub disconnected: usize,
+    pub never_connected: usize,
+    pub static_peers: usize,
+}
+
+/// Status of a single peer.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerInfo {
+    pub peer_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub multiaddr: Option<String>,
+    pub is_static: bool,
+    /// One of `"connected"`, `"disconnected"`, `"never_connected"`.
+    pub connection_state: String,
+    pub has_stream: bool,
+    /// Seconds since connection was established (present only when connected).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connected_duration_secs: Option<f64>,
+    /// Seconds since disconnection (present only when disconnected).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disconnected_duration_secs: Option<f64>,
+    /// Total number of times this peer has connected.
+    pub connection_count: u64,
+    /// Seconds since last successful broadcast to this peer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_broadcast_secs_ago: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_peer_id(seed: u8) -> PeerId {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        let kp = libp2p::identity::Keypair::ed25519_from_bytes(bytes).unwrap();
+        kp.public().to_peer_id()
+    }
+
+    fn test_multiaddr(port: u16) -> Multiaddr {
+        format!("/ip4/127.0.0.1/tcp/{port}").parse().unwrap()
+    }
+
+    #[test]
+    fn static_peers_start_as_never_connected() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        let addr_a = test_multiaddr(9001);
+        tracker.register_static_peers(&[(peer_a, addr_a)]);
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.summary.total, 1);
+        assert_eq!(snap.summary.never_connected, 1);
+        assert_eq!(snap.summary.static_peers, 1);
+        assert_eq!(snap.peers[0].connection_state, "never_connected");
+        assert!(snap.peers[0].is_static);
+        assert_eq!(snap.peers[0].connection_count, 0);
+    }
+
+    #[test]
+    fn connect_transitions_from_never_connected() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        let addr_a = test_multiaddr(9001);
+        tracker.register_static_peers(&[(peer_a, addr_a.clone())]);
+        tracker.on_connected(peer_a, Some(addr_a));
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.summary.connected, 1);
+        assert_eq!(snap.summary.never_connected, 0);
+        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_count, 1);
+        assert!(snap.peers[0].connected_duration_secs.is_some());
+    }
+
+    #[test]
+    fn disconnect_then_reconnect() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        let addr_a = test_multiaddr(9001);
+        tracker.register_static_peers(&[(peer_a, addr_a.clone())]);
+
+        // Connect
+        tracker.on_connected(peer_a, Some(addr_a.clone()));
+        tracker.on_stream_opened(peer_a);
+        assert!(tracker.snapshot().peers[0].has_stream);
+
+        // Disconnect
+        tracker.on_disconnected(peer_a);
+        let snap = tracker.snapshot();
+        assert_eq!(snap.peers[0].connection_state, "disconnected");
+        assert!(!snap.peers[0].has_stream);
+        assert!(snap.peers[0].disconnected_duration_secs.is_some());
+
+        // Reconnect
+        tracker.on_connected(peer_a, Some(addr_a));
+        let snap = tracker.snapshot();
+        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert_eq!(snap.peers[0].connection_count, 2);
+        assert!(snap.peers[0].disconnected_duration_secs.is_none());
+    }
+
+    #[test]
+    fn non_static_peer_tracked_on_connect() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_b = test_peer_id(2);
+        let addr_b = test_multiaddr(9002);
+        tracker.on_connected(peer_b, Some(addr_b));
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.summary.total, 1);
+        assert_eq!(snap.summary.static_peers, 0);
+        assert!(!snap.peers[0].is_static);
+        assert_eq!(snap.peers[0].connection_state, "connected");
+    }
+
+    #[test]
+    fn broadcast_failure_closes_stream_but_keeps_connection() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        tracker.on_connected(peer_a, None);
+        tracker.on_stream_opened(peer_a);
+
+        // Broadcast fails for peer_a
+        tracker.on_broadcast_result(&[peer_a]);
+
+        let snap = tracker.snapshot();
+        // Connection is still up, only stream is lost.
+        assert_eq!(snap.peers[0].connection_state, "connected");
+        assert!(!snap.peers[0].has_stream);
+        // Failed peer should not get last_broadcast_at updated.
+        assert!(snap.peers[0].last_broadcast_secs_ago.is_none());
+    }
+
+    #[test]
+    fn broadcast_success_updates_last_broadcast() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        tracker.on_connected(peer_a, None);
+        tracker.on_stream_opened(peer_a);
+
+        assert!(tracker.snapshot().peers[0].last_broadcast_secs_ago.is_none());
+
+        tracker.on_broadcast_result(&[]);
+        let snap = tracker.snapshot();
+        assert!(snap.peers[0].last_broadcast_secs_ago.is_some());
+    }
+
+    #[test]
+    fn broadcast_result_only_updates_peers_with_stream() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let peer_a = test_peer_id(1);
+        let peer_b = test_peer_id(2);
+        tracker.on_connected(peer_a, None);
+        tracker.on_stream_opened(peer_a);
+        tracker.on_connected(peer_b, None);
+        // peer_b has no stream
+
+        tracker.on_broadcast_result(&[]);
+        let snap = tracker.snapshot();
+        let a = snap.peers.iter().find(|p| p.peer_id == peer_a.to_string()).unwrap();
+        let b = snap.peers.iter().find(|p| p.peer_id == peer_b.to_string()).unwrap();
+        assert!(a.last_broadcast_secs_ago.is_some());
+        assert!(b.last_broadcast_secs_ago.is_none());
+    }
+
+    #[test]
+    fn snapshot_sorts_static_peers_first() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let static_peer = test_peer_id(1);
+        let dynamic_peer = test_peer_id(2);
+
+        tracker.on_connected(dynamic_peer, None);
+        tracker.register_static_peers(&[(static_peer, test_multiaddr(9001))]);
+
+        let snap = tracker.snapshot();
+        assert!(snap.peers[0].is_static);
+        assert!(!snap.peers[1].is_static);
+    }
+
+    #[test]
+    fn empty_tracker_produces_valid_snapshot() {
+        let local = test_peer_id(0);
+        let tracker = PeerStatusTracker::new(local);
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.summary.total, 0);
+        assert_eq!(snap.summary.connected, 0);
+        assert!(snap.peers.is_empty());
+        assert_eq!(snap.local_peer_id, local.to_string());
+    }
+}

--- a/crates/builder/src/default/service.rs
+++ b/crates/builder/src/default/service.rs
@@ -17,7 +17,7 @@ use crate::{
     traits::{NodeBounds, PoolBounds},
 };
 use eyre::WrapErr as _;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use reth_basic_payload_builder::{BasicPayloadJobGenerator, BasicPayloadJobGeneratorConfig};
 use reth_node_api::NodeTypes;
@@ -32,6 +32,7 @@ pub struct DefaultBuilderServiceBuilder {
     pub config: BuilderConfig,
     pub da_config: OpDAConfig,
     pub gas_limit_config: OpGasLimitConfig,
+    pub peer_status_sink: Arc<OnceLock<crate::broadcast::PeerStatusTracker>>,
 }
 
 impl<Node, Pool> PayloadServiceBuilder<Node, Pool, OpEvmConfig> for DefaultBuilderServiceBuilder
@@ -88,6 +89,7 @@ where
             node,
             outgoing_message_tx: _,
             mut incoming_message_rxs,
+            peer_status,
         } = broadcast_builder
             .with_agent_version(AGENT_VERSION.to_string())
             .with_protocol(FLASHBLOCKS_STREAM_PROTOCOL)
@@ -97,6 +99,7 @@ where
             .with_max_peer_count(self.config.flashblocks.p2p_max_peer_count)
             .try_build()
             .wrap_err("failed to build flashblocks p2p node")?;
+        let _ = self.peer_status_sink.set(peer_status);
         let multiaddrs = node.multiaddrs();
         ctx.task_executor().spawn_task(async move {
             if let Err(e) = node.run().await {

--- a/crates/builder/src/flashblocks/service.rs
+++ b/crates/builder/src/flashblocks/service.rs
@@ -13,7 +13,8 @@ use crate::{
     traits::{NodeBounds, PoolBounds},
 };
 use eyre::WrapErr as _;
-use std::{sync::Arc, time::Duration};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 use reth_basic_payload_builder::BasicPayloadJobGeneratorConfig;
 use reth_node_api::NodeTypes;
@@ -25,6 +26,7 @@ use reth_provider::CanonStateSubscriptions;
 pub struct FlashblocksServiceBuilder {
     pub config: BuilderConfig,
     pub bridge_intercept: xlayer_bridge_intercept::BridgeInterceptConfig,
+    pub peer_status_sink: Arc<OnceLock<crate::broadcast::PeerStatusTracker>>,
 }
 
 impl FlashblocksServiceBuilder {
@@ -92,6 +94,7 @@ impl FlashblocksServiceBuilder {
             node,
             outgoing_message_tx,
             mut incoming_message_rxs,
+            peer_status,
         } = broadcast_builder
             .with_agent_version(AGENT_VERSION.to_string())
             .with_protocol(FLASHBLOCKS_STREAM_PROTOCOL)
@@ -101,6 +104,7 @@ impl FlashblocksServiceBuilder {
             .with_max_peer_count(self.config.flashblocks.p2p_max_peer_count)
             .try_build()
             .wrap_err("failed to build flashblocks p2p node")?;
+        let _ = self.peer_status_sink.set(peer_status);
         let multiaddrs = node.multiaddrs();
         ctx.task_executor().spawn_task(async move {
             if let Err(e) = node.run().await {

--- a/crates/builder/src/tests/framework/instance.rs
+++ b/crates/builder/src/tests/framework/instance.rs
@@ -118,6 +118,7 @@ impl LocalInstance {
                 FlashblocksServiceBuilder {
                     config: builder_config,
                     bridge_intercept: Default::default(),
+                    peer_status_sink: std::sync::Arc::new(std::sync::OnceLock::new()),
                 },
             ))
             .with_add_ons(addons)

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 default = []
 
 [dependencies]
+xlayer-builder.workspace = true
 xlayer-flashblocks.workspace = true
 
 # reth

--- a/crates/rpc/src/default.rs
+++ b/crates/rpc/src/default.rs
@@ -6,6 +6,7 @@ use jsonrpsee::{
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::SequencerClient;
 
+use xlayer_builder::broadcast::peer_status::{PeerStatusSnapshot, PeerStatusTracker};
 use xlayer_flashblocks::FlashblockStateCache;
 
 /// Trait for accessing sequencer client from backend
@@ -25,18 +26,29 @@ pub trait DefaultRpcExtApi {
     /// receiving and caching flashblock data.
     #[method(name = "flashblocksEnabled")]
     async fn flashblocks_enabled(&self) -> RpcResult<bool>;
+
+    /// Returns the status of all flashblocks P2P peers, including connected,
+    /// disconnected, and never-connected static peers.
+    ///
+    /// Returns `None` on non-sequencer nodes that have no P2P layer.
+    #[method(name = "flashblocksPeerStatus")]
+    async fn flashblocks_peer_status(&self) -> RpcResult<Option<PeerStatusSnapshot>>;
 }
 
 /// X Layer default Eth JSON-RPC API extension implementation.
 #[derive(Debug, Clone)]
 pub struct DefaultRpcExt {
     flashblocks_state: Option<FlashblockStateCache<OpPrimitives>>,
+    peer_status: Option<PeerStatusTracker>,
 }
 
 impl DefaultRpcExt {
     /// Creates a new [`DefaultRpcExt`].
-    pub fn new(flashblocks_state: Option<FlashblockStateCache<OpPrimitives>>) -> Self {
-        Self { flashblocks_state }
+    pub fn new(
+        flashblocks_state: Option<FlashblockStateCache<OpPrimitives>>,
+        peer_status: Option<PeerStatusTracker>,
+    ) -> Self {
+        Self { flashblocks_state, peer_status }
     }
 }
 
@@ -45,6 +57,11 @@ impl DefaultRpcExtApiServer for DefaultRpcExt {
     /// Handler for: `eth_flashblocksEnabled`
     async fn flashblocks_enabled(&self) -> RpcResult<bool> {
         Ok(self.flashblocks_state.as_ref().is_some_and(|cache| cache.get_confirm_height() > 0))
+    }
+
+    /// Handler for: `eth_flashblocksPeerStatus`
+    async fn flashblocks_peer_status(&self) -> RpcResult<Option<PeerStatusSnapshot>> {
+        Ok(self.peer_status.as_ref().map(|tracker| tracker.snapshot()))
     }
 }
 
@@ -55,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_flashblocks_disabled_when_no_cache() {
-        let ext = DefaultRpcExt::new(None);
+        let ext = DefaultRpcExt::new(None, None);
         assert!(ext.flashblocks_state.is_none());
     }
 
@@ -71,7 +88,13 @@ mod tests {
             ),
             ChangesetCache::new(),
         );
-        let ext = DefaultRpcExt::new(Some(cache));
+        let ext = DefaultRpcExt::new(Some(cache), None);
         assert!(ext.flashblocks_state.as_ref().unwrap().get_confirm_height() == 0);
+    }
+
+    #[test]
+    fn test_peer_status_returns_none_when_no_tracker() {
+        let ext = DefaultRpcExt::new(None, None);
+        assert!(ext.peer_status.is_none());
     }
 }

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -58,41 +58,59 @@ async fn fb_flashblocks_enabled_returns_false_on_non_fb_node_test() {
 // Flashblocks P2P peer status tests
 // ========================================================================
 
-/// Verifies that `eth_flashblocksPeerStatus` returns a valid, well-formed
-/// response on the sequencer node (which has the P2P broadcast layer).
+/// Verifies that `eth_flashblocksPeerStatus` returns valid responses on both
+/// sequencers and that each sees the other as a static peer.
 #[tokio::test]
+#[ignore = "requires conductor-enabled devnet with P2P keys"]
 async fn fb_peer_status_returns_data_on_sequencer_test() {
-    let seq_client = operations::create_test_client(operations::DEFAULT_L2_SEQ_URL);
+    // seq1 → expects localPeerId = SEQ1, static peer = SEQ2
+    let seq1_status = operations::eth_flashblocks_peer_status(&operations::create_test_client(
+        operations::DEFAULT_L2_SEQ_URL,
+    ))
+    .await
+    .expect("RPC failed")
+    .expect("seq1 should return peer status");
 
-    let status = operations::eth_flashblocks_peer_status(&seq_client)
-        .await
-        .expect("eth_flashblocksPeerStatus RPC call failed")
-        .expect("sequencer should return peer status, not null");
-
-    // Top-level structure
-    assert!(!status["localPeerId"].as_str().unwrap().is_empty(), "localPeerId must be non-empty");
-
-    // Summary counts must be consistent
-    let summary = &status["summary"];
+    assert_eq!(
+        seq1_status["localPeerId"].as_str().unwrap(),
+        operations::DEFAULT_SEQ_FB_P2P_PEER_ID
+    );
+    let summary = &seq1_status["summary"];
     let total = summary["total"].as_u64().unwrap();
-    let connected = summary["connected"].as_u64().unwrap();
-    let disconnected = summary["disconnected"].as_u64().unwrap();
-    let never_connected = summary["neverConnected"].as_u64().unwrap();
-    assert_eq!(total, connected + disconnected + never_connected, "summary counts must add up");
+    assert_eq!(
+        total,
+        summary["connected"].as_u64().unwrap()
+            + summary["disconnected"].as_u64().unwrap()
+            + summary["neverConnected"].as_u64().unwrap(),
+        "summary counts must add up"
+    );
+    let seq2_on_seq1 = seq1_status["peers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["peerId"].as_str() == Some(operations::DEFAULT_SEQ2_FB_P2P_PEER_ID))
+        .expect("seq2 must appear in seq1's peer list");
+    assert!(seq2_on_seq1["isStatic"].as_bool().unwrap());
 
-    // Validate each peer entry
-    let peers = status["peers"].as_array().expect("peers must be an array");
-    assert_eq!(peers.len(), total as usize);
-    for peer in peers {
-        assert!(!peer["peerId"].as_str().unwrap().is_empty());
-        assert!(peer["isStatic"].is_boolean());
-        assert!(peer["connectionCount"].is_u64());
-        let state = peer["connectionState"].as_str().unwrap();
-        assert!(
-            ["connected", "disconnected", "never_connected"].contains(&state),
-            "invalid connectionState: {state}"
-        );
-    }
+    // seq2 → expects localPeerId = SEQ2, static peer = SEQ1
+    let seq2_status = operations::eth_flashblocks_peer_status(&operations::create_test_client(
+        operations::DEFAULT_L2_SEQ2_URL,
+    ))
+    .await
+    .expect("RPC failed")
+    .expect("seq2 should return peer status");
+
+    assert_eq!(
+        seq2_status["localPeerId"].as_str().unwrap(),
+        operations::DEFAULT_SEQ2_FB_P2P_PEER_ID
+    );
+    let seq1_on_seq2 = seq2_status["peers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["peerId"].as_str() == Some(operations::DEFAULT_SEQ_FB_P2P_PEER_ID))
+        .expect("seq1 must appear in seq2's peer list");
+    assert!(seq1_on_seq2["isStatic"].as_bool().unwrap());
 }
 
 /// Verifies that `eth_flashblocksPeerStatus` returns `null` on an RPC node

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -55,6 +55,74 @@ async fn fb_flashblocks_enabled_returns_false_on_non_fb_node_test() {
 }
 
 // ========================================================================
+// Flashblocks P2P peer status tests
+// ========================================================================
+
+/// Verifies that `eth_flashblocksPeerStatus` returns a valid, well-formed
+/// response on the sequencer node (which has the P2P broadcast layer).
+#[tokio::test]
+async fn fb_peer_status_returns_data_on_sequencer_test() {
+    let seq_client = operations::create_test_client(operations::DEFAULT_L2_SEQ_URL);
+
+    let status = operations::eth_flashblocks_peer_status(&seq_client)
+        .await
+        .expect("eth_flashblocksPeerStatus RPC call failed")
+        .expect("sequencer should return peer status, not null");
+
+    // Top-level structure
+    assert!(!status["localPeerId"].as_str().unwrap().is_empty(), "localPeerId must be non-empty");
+
+    // Summary counts must be consistent
+    let summary = &status["summary"];
+    let total = summary["total"].as_u64().unwrap();
+    let connected = summary["connected"].as_u64().unwrap();
+    let disconnected = summary["disconnected"].as_u64().unwrap();
+    let never_connected = summary["neverConnected"].as_u64().unwrap();
+    assert_eq!(total, connected + disconnected + never_connected, "summary counts must add up");
+
+    // Validate each peer entry
+    let peers = status["peers"].as_array().expect("peers must be an array");
+    assert_eq!(peers.len(), total as usize);
+    for peer in peers {
+        assert!(!peer["peerId"].as_str().unwrap().is_empty());
+        assert!(peer["isStatic"].is_boolean());
+        assert!(peer["connectionCount"].is_u64());
+        let state = peer["connectionState"].as_str().unwrap();
+        assert!(
+            ["connected", "disconnected", "never_connected"].contains(&state),
+            "invalid connectionState: {state}"
+        );
+    }
+}
+
+/// Verifies that `eth_flashblocksPeerStatus` returns `null` on an RPC node
+/// that does not have the P2P broadcast layer.
+#[tokio::test]
+async fn fb_peer_status_returns_null_on_rpc_node_test() {
+    let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
+
+    let result = operations::eth_flashblocks_peer_status(&fb_client)
+        .await
+        .expect("eth_flashblocksPeerStatus RPC call failed");
+
+    assert!(result.is_none(), "RPC node (non-sequencer) should return null for peer status");
+}
+
+/// Verifies that `eth_flashblocksPeerStatus` returns `null` on a node without
+/// flashblocks.
+#[tokio::test]
+#[ignore = "requires non-flashblocks node"]
+async fn fb_peer_status_returns_null_on_non_fb_node_test() {
+    let non_fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_NO_FB);
+
+    let result = operations::eth_flashblocks_peer_status(&non_fb_client)
+        .await
+        .expect("eth_flashblocksPeerStatus RPC call failed");
+
+    assert!(result.is_none(), "non-flashblocks node should return null for peer status");
+}
+
+// ========================================================================
 // Flashblocks pending state tests
 // ========================================================================
 

--- a/crates/tests/operations/eth_rpc.rs
+++ b/crates/tests/operations/eth_rpc.rs
@@ -372,11 +372,23 @@ pub async fn txpool_status(client_rpc: &HttpClient) -> Result<Value> {
     Ok(result)
 }
 
-/// For eth_flashblocksEnabled
+/// For `eth_flashblocksEnabled`
 pub async fn eth_flashblocks_enabled(client_rpc: &HttpClient) -> Result<bool> {
     let result: bool = tokio::time::timeout(
         RPC_TIMEOUT,
         client_rpc.request("eth_flashblocksEnabled", jsonrpsee::rpc_params![]),
+    )
+    .await??;
+    Ok(result)
+}
+
+/// For `eth_flashblocksPeerStatus`
+pub async fn eth_flashblocks_peer_status(
+    client_rpc: &HttpClient,
+) -> Result<Option<serde_json::Value>> {
+    let result: Option<serde_json::Value> = tokio::time::timeout(
+        RPC_TIMEOUT,
+        client_rpc.request("eth_flashblocksPeerStatus", jsonrpsee::rpc_params![]),
     )
     .await??;
     Ok(result)

--- a/crates/tests/operations/manager.rs
+++ b/crates/tests/operations/manager.rs
@@ -13,12 +13,18 @@ pub const DEFAULT_L1_NETWORK_URL: &str = "http://localhost:8545";
 pub const DEFAULT_L2_CHAIN_ID: u64 = 195;
 /// Default L2 sequencer URL for testing
 pub const DEFAULT_L2_SEQ_URL: &str = "http://localhost:8123";
+/// Default L2 sequencer 2 URL for testing (conductor failover peer)
+pub const DEFAULT_L2_SEQ2_URL: &str = "http://localhost:8223";
 /// Default L2 RPC node URL for testing
 pub const DEFAULT_L2_NETWORK_URL: &str = "http://localhost:8124";
 // Default L2 RPC node with flashblocks enabled
 pub const DEFAULT_L2_NETWORK_URL_FB: &str = "http://localhost:8124";
 // Default L2 RPC node with flashblocks disabled
 pub const DEFAULT_L2_NETWORK_URL_NO_FB: &str = "http://localhost:8128";
+// Flashblocks P2P peer IDs derived from fb-p2p-key files provisioned in 3-op-init.sh
+pub const DEFAULT_SEQ_FB_P2P_PEER_ID: &str = "12D3KooWC6qFQzcS6V6Tp53nRqw2pmU1snjSYq7H4Q6ckTWAskTt";
+pub const DEFAULT_SEQ2_FB_P2P_PEER_ID: &str =
+    "12D3KooWGnxtRXJWhNtwKmRjpqj5QFQPskjWJkC7AkGWhCXBM6ed";
 /// Default Flashblocks WebSocket URL for testing
 pub const DEFAULT_SEQ_FLASHBLOCKS_WS_URL: &str = "ws://localhost:11111";
 /// Default Flashblocks WebSocket URL for testing


### PR DESCRIPTION
## Summary

Expose the current flashblocks builder p2p peers status, via a new JSON-RPC method `eth_flashblocksPeerStatus`, enabling operators to monitor connected, disconnected, and never-connected static peers with timing information for debugging broadcast issues.

Note that the static peers configured inside `flashblocks.p2p_known_peers` are always shown first in the returned response of the api call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)