### PR TITLE
chore(release): bump xlayer-reth to version v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14004,7 +14004,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-bridge-intercept"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-primitives",
  "thiserror 2.0.18",
@@ -14013,7 +14013,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-builder"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -14119,7 +14119,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-chainspec"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -14141,7 +14141,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-e2e-test"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -14162,7 +14162,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-flashblocks"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -14242,7 +14242,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-legacy-rpc"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14256,7 +14256,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-monitor"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14281,7 +14281,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-reth-node"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -14338,7 +14338,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-reth-tools"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -14376,7 +14376,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-rpc"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14420,7 +14420,7 @@ dependencies = [
 
 [[package]]
 name = "xlayer-version"
-version = "0.1.0"
+version = "0.0.6"
 dependencies = [
  "reth-node-core",
  "vergen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.1.0"
+version = "0.0.6"
 edition = "2024"
 rust-version = "1.93.0"
 license = "MIT OR Apache-2.0"
@@ -23,6 +23,7 @@ members = [
     "crates/rpc",
     "crates/tests",
     "crates/version",
+    "crates/builder/src/tests/framework/macros",
 
     "bin/tools",
     "bin/node",

--- a/crates/builder/src/tests/framework/macros/Cargo.toml
+++ b/crates/builder/src/tests/framework/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macros"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 description = "Macros supporting the tests infrastructure for flashblock-builder"
 
 [lib]


### PR DESCRIPTION
## Summary

- Update workspace version from 0.1.0 to 0.0.6
- Add macros crate to workspace members for version inheritance
- Switch macros crate to use workspace version and edition

🤖 Generated with [Claude Code](https://claude.com/claude-code)