### PR TITLE
test(legacy-rpc): add e2e test coverage support for legacy RPC forwarding

### DIFF
--- a/bin/node/src/args.rs
+++ b/bin/node/src/args.rs
@@ -4,6 +4,7 @@ use url::Url;
 
 use xlayer_bridge_intercept::BridgeInterceptConfig;
 use xlayer_builder::args::BuilderArgs;
+use xlayer_legacy_rpc::LegacyRpcRouterConfig;
 use xlayer_monitor::FullLinkMonitorArgs;
 
 /// Bridge intercept CLI arguments
@@ -111,7 +112,6 @@ impl XLayerInterceptArgs {
         Ok(())
     }
 }
-
 /// X Layer specific configuration flags
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "X Layer")]
@@ -207,6 +207,17 @@ pub struct LegacyRpcArgs {
         requires = "legacy_rpc_url"
     )]
     pub legacy_rpc_timeout: Duration,
+
+    /// WARNING: This flag is intended for e2e testing only and should NOT be set
+    /// in production. The optional flag overrides the legacy RPC cutoff block height
+    /// derived from the chain genesis number.
+    #[arg(
+        long = "rpc.legacy-cutoff-override",
+        value_name = "BLOCK_NUMBER",
+        requires = "legacy_rpc_url",
+        help = "[TEST ONLY] Override the legacy RPC cutoff block height (default: derived from genesis)"
+    )]
+    pub legacy_cutoff_override: Option<u64>,
 }
 
 impl LegacyRpcArgs {
@@ -232,6 +243,18 @@ impl LegacyRpcArgs {
         }
 
         Ok(())
+    }
+
+    pub fn to_legacy_rpc_config(&self, mut genesis_block: u64) -> LegacyRpcRouterConfig {
+        if self.legacy_cutoff_override.is_some() {
+            genesis_block = self.legacy_cutoff_override.unwrap();
+        }
+        LegacyRpcRouterConfig {
+            enabled: self.legacy_rpc_url.is_some(),
+            legacy_endpoint: self.legacy_rpc_url.clone().unwrap_or_default(),
+            cutoff_block: genesis_block,
+            timeout: self.legacy_rpc_timeout,
+        }
     }
 }
 
@@ -299,6 +322,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://localhost:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
+            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -308,6 +332,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("https://mainnet.infura.io/v3/YOUR-PROJECT-ID".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
+            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -317,6 +342,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://192.168.1.100:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
+            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -326,6 +352,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("not-a-valid-url".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
+            legacy_cutoff_override: None,
         };
         let result = args.validate();
         assert!(result.is_err());
@@ -337,6 +364,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
+            legacy_cutoff_override: None,
         };
         let result = args.validate();
         assert!(result.is_err());
@@ -347,6 +375,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("ftp://example.com".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
+            legacy_cutoff_override: None,
         };
         // This should pass validation (URL is valid, even if scheme is unusual)
         assert!(args.validate().is_ok());
@@ -357,6 +386,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://localhost:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(0),
+            legacy_cutoff_override: None,
         };
         let result = args.validate();
         assert!(result.is_err());
@@ -368,6 +398,7 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://localhost:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(60),
+            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -435,6 +466,7 @@ mod tests {
             legacy: LegacyRpcArgs {
                 legacy_rpc_url: Some("invalid-url".to_string()),
                 legacy_rpc_timeout: Duration::from_secs(30),
+                legacy_cutoff_override: None,
             },
             ..Default::default()
         };

--- a/bin/node/src/args.rs
+++ b/bin/node/src/args.rs
@@ -4,7 +4,6 @@ use url::Url;
 
 use xlayer_bridge_intercept::BridgeInterceptConfig;
 use xlayer_builder::args::BuilderArgs;
-use xlayer_legacy_rpc::LegacyRpcRouterConfig;
 use xlayer_monitor::FullLinkMonitorArgs;
 
 /// Bridge intercept CLI arguments
@@ -207,17 +206,6 @@ pub struct LegacyRpcArgs {
         requires = "legacy_rpc_url"
     )]
     pub legacy_rpc_timeout: Duration,
-
-    /// WARNING: This flag is intended for e2e testing only and should NOT be set
-    /// in production. The optional flag overrides the legacy RPC cutoff block height
-    /// derived from the chain genesis number.
-    #[arg(
-        long = "rpc.legacy-cutoff-override",
-        value_name = "BLOCK_NUMBER",
-        requires = "legacy_rpc_url",
-        help = "[TEST ONLY] Override the legacy RPC cutoff block height (default: derived from genesis)"
-    )]
-    pub legacy_cutoff_override: Option<u64>,
 }
 
 impl LegacyRpcArgs {
@@ -243,18 +231,6 @@ impl LegacyRpcArgs {
         }
 
         Ok(())
-    }
-
-    pub fn to_legacy_rpc_config(&self, mut genesis_block: u64) -> LegacyRpcRouterConfig {
-        if let Some(cutoff) = self.legacy_cutoff_override {
-            genesis_block = cutoff;
-        }
-        LegacyRpcRouterConfig {
-            enabled: self.legacy_rpc_url.is_some(),
-            legacy_endpoint: self.legacy_rpc_url.clone().unwrap_or_default(),
-            cutoff_block: genesis_block,
-            timeout: self.legacy_rpc_timeout,
-        }
     }
 }
 
@@ -322,7 +298,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://localhost:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
-            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -332,7 +307,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("https://mainnet.infura.io/v3/YOUR-PROJECT-ID".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
-            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -342,7 +316,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://192.168.1.100:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
-            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -352,7 +325,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("not-a-valid-url".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
-            legacy_cutoff_override: None,
         };
         let result = args.validate();
         assert!(result.is_err());
@@ -364,7 +336,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
-            legacy_cutoff_override: None,
         };
         let result = args.validate();
         assert!(result.is_err());
@@ -375,7 +346,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("ftp://example.com".to_string()),
             legacy_rpc_timeout: Duration::from_secs(30),
-            legacy_cutoff_override: None,
         };
         // This should pass validation (URL is valid, even if scheme is unusual)
         assert!(args.validate().is_ok());
@@ -386,7 +356,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://localhost:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(0),
-            legacy_cutoff_override: None,
         };
         let result = args.validate();
         assert!(result.is_err());
@@ -398,7 +367,6 @@ mod tests {
         let args = LegacyRpcArgs {
             legacy_rpc_url: Some("http://localhost:8545".to_string()),
             legacy_rpc_timeout: Duration::from_secs(60),
-            legacy_cutoff_override: None,
         };
         assert!(args.validate().is_ok());
     }
@@ -466,7 +434,6 @@ mod tests {
             legacy: LegacyRpcArgs {
                 legacy_rpc_url: Some("invalid-url".to_string()),
                 legacy_rpc_timeout: Duration::from_secs(30),
-                legacy_cutoff_override: None,
             },
             ..Default::default()
         };

--- a/bin/node/src/args.rs
+++ b/bin/node/src/args.rs
@@ -246,8 +246,8 @@ impl LegacyRpcArgs {
     }
 
     pub fn to_legacy_rpc_config(&self, mut genesis_block: u64) -> LegacyRpcRouterConfig {
-        if self.legacy_cutoff_override.is_some() {
-            genesis_block = self.legacy_cutoff_override.unwrap();
+        if let Some(cutoff) = self.legacy_cutoff_override {
+            genesis_block = cutoff;
         }
         LegacyRpcRouterConfig {
             enabled: self.legacy_rpc_url.is_some(),

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -93,13 +93,6 @@ fn main() {
             let xlayer_args = args.xlayer_args.clone();
             let datadir = builder.config().datadir().clone();
 
-            let legacy_config = LegacyRpcRouterConfig {
-                enabled: xlayer_args.legacy.legacy_rpc_url.is_some(),
-                legacy_endpoint: xlayer_args.legacy.legacy_rpc_url.unwrap_or_default(),
-                cutoff_block: genesis_block,
-                timeout: xlayer_args.legacy.legacy_rpc_timeout,
-            };
-
             // For X Layer full link monitor
             let monitor = XLayerMonitor::new(
                 xlayer_args.monitor,
@@ -109,7 +102,7 @@ fn main() {
 
             let add_ons = op_node.add_ons().with_rpc_middleware((
                 RpcMonitorLayer::new(monitor.clone()),    // Execute first
-                LegacyRpcRouterLayer::new(legacy_config), // Execute second
+                LegacyRpcRouterLayer::new(xlayer_args.legacy.to_legacy_rpc_config(genesis_block)), // Execute second
             ));
 
             // Parse and validate bridge intercept configuration

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -30,7 +30,7 @@ use xlayer_flashblocks::{
     FlashblockSequenceValidator, FlashblockStateCache, FlashblocksPersistCtx, FlashblocksPubSub,
     FlashblocksRpcCtx, FlashblocksRpcService, WsFlashBlockStream, XLayerEngineValidatorBuilder,
 };
-use xlayer_legacy_rpc::layer::LegacyRpcRouterLayer;
+use xlayer_legacy_rpc::{layer::LegacyRpcRouterLayer, LegacyRpcRouterConfig};
 use xlayer_monitor::{start_monitor_handle, RpcMonitorLayer, XLayerMonitor};
 use xlayer_rpc::{
     DefaultRpcExt, DefaultRpcExtApiServer, FlashblocksEthApiExt, FlashblocksEthApiOverrideServer,
@@ -93,6 +93,13 @@ fn main() {
             let xlayer_args = args.xlayer_args.clone();
             let datadir = builder.config().datadir().clone();
 
+            let legacy_config = LegacyRpcRouterConfig {
+                enabled: xlayer_args.legacy.legacy_rpc_url.is_some(),
+                legacy_endpoint: xlayer_args.legacy.legacy_rpc_url.unwrap_or_default(),
+                cutoff_block: genesis_block,
+                timeout: xlayer_args.legacy.legacy_rpc_timeout,
+            };
+
             // For X Layer full link monitor
             let monitor = XLayerMonitor::new(
                 xlayer_args.monitor,
@@ -102,7 +109,7 @@ fn main() {
 
             let add_ons = op_node.add_ons().with_rpc_middleware((
                 RpcMonitorLayer::new(monitor.clone()),    // Execute first
-                LegacyRpcRouterLayer::new(xlayer_args.legacy.to_legacy_rpc_config(genesis_block)), // Execute second
+                LegacyRpcRouterLayer::new(legacy_config), // Execute second
             ));
 
             // Parse and validate bridge intercept configuration

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -30,7 +30,7 @@ use xlayer_flashblocks::{
     FlashblockSequenceValidator, FlashblockStateCache, FlashblocksPersistCtx, FlashblocksPubSub,
     FlashblocksRpcCtx, FlashblocksRpcService, WsFlashBlockStream, XLayerEngineValidatorBuilder,
 };
-use xlayer_legacy_rpc::{layer::LegacyRpcRouterLayer, LegacyRpcRouterConfig};
+use xlayer_legacy_rpc::layer::LegacyRpcRouterLayer;
 use xlayer_monitor::{start_monitor_handle, RpcMonitorLayer, XLayerMonitor};
 use xlayer_rpc::{
     DefaultRpcExt, DefaultRpcExtApiServer, FlashblocksEthApiExt, FlashblocksEthApiOverrideServer,

--- a/crates/legacy-rpc/src/get_logs.rs
+++ b/crates/legacy-rpc/src/get_logs.rs
@@ -359,8 +359,7 @@ mod tests {
             };
             Box::pin(async move {
                 let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
-                let result =
-                    json.get("result").cloned().unwrap_or(serde_json::Value::Null);
+                let result = json.get("result").cloned().unwrap_or(serde_json::Value::Null);
                 let payload = jsonrpsee_types::ResponsePayload::success(&result).into();
                 MethodResponse::response(Id::Number(1), payload, usize::MAX)
             })

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -1227,16 +1227,16 @@ async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
     }
 }
 
-/// Tests that `eth_getBlockByNumber` correctly forwards to legacy for blocks
-/// below the cutoff height, proving the block-param routing path works.
+/// Tests `eth_getBlockByNumber` routing at the cutoff boundary:
+/// blocks below cutoff are forwarded to legacy, blocks at cutoff are served locally.
 #[tokio::test]
-async fn test_legacy_get_block_by_number_forwarding() {
+async fn test_legacy_get_block_by_number_routing() {
     let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
     assert_legacy_preconditions(&client).await;
     let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
 
-    // Below cutoff — should be forwarded to legacy endpoint
-    let block = operations::eth_get_block_by_number_or_hash(
+    // Below cutoff — forwarded to legacy endpoint
+    let legacy_block = operations::eth_get_block_by_number_or_hash(
         &client,
         operations::BlockId::Number(cutoff - 1),
         false,
@@ -1244,13 +1244,26 @@ async fn test_legacy_get_block_by_number_forwarding() {
     .await
     .expect("Failed to get block below cutoff via legacy");
 
-    assert!(!block.is_null(), "Legacy block should not be null");
-    assert!(block["hash"].is_string(), "Legacy block should have hash");
-
-    let block_num_str = block["number"].as_str().expect("Block should have number");
-    let block_num = u64::from_str_radix(block_num_str.trim_start_matches("0x"), 16)
+    assert!(!legacy_block.is_null(), "Legacy block should not be null");
+    let legacy_num_str = legacy_block["number"].as_str().expect("Block should have number");
+    let legacy_num = u64::from_str_radix(legacy_num_str.trim_start_matches("0x"), 16)
         .expect("Should parse block number");
-    assert_eq!(block_num, cutoff - 1, "Block number should match requested");
+    assert_eq!(legacy_num, cutoff - 1, "Block number should match requested");
+    println!("Below cutoff: block #{legacy_num} retrieved via legacy");
 
-    println!("Legacy forwarding OK: block #{block_num} retrieved via legacy endpoint");
+    // At cutoff — served locally (>= cutoff is local)
+    let local_block = operations::eth_get_block_by_number_or_hash(
+        &client,
+        operations::BlockId::Number(cutoff),
+        false,
+    )
+    .await
+    .expect("Failed to get block at cutoff from local node");
+
+    assert!(!local_block.is_null(), "Local block should not be null");
+    let local_num_str = local_block["number"].as_str().expect("Block should have number");
+    let local_num = u64::from_str_radix(local_num_str.trim_start_matches("0x"), 16)
+        .expect("Should parse block number");
+    assert_eq!(local_num, cutoff, "Block number should match requested");
+    println!("At cutoff: block #{local_num} served locally");
 }

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -1008,3 +1008,249 @@ async fn test_new_transaction_types(#[case] test_name: &str) {
         _ => panic!("Unknown test case: {test_name}"),
     }
 }
+
+// ============================================================================
+// Legacy RPC Routing Tests
+// ============================================================================
+//
+// These tests exercise the `LegacyRpcRouterLayer` middleware that intercepts
+// JSON-RPC calls and routes them to either the local reth node or a legacy
+// endpoint based on block height cutoffs.
+//
+// The devnet must be started with `--rpc.legacy-url` and
+// `--rpc.legacy-cutoff-override=8593925` on the RPC node.
+
+/// ERC20 Transfer event topic: `keccak256("Transfer(address,address,uint256)")`
+const TRANSFER_EVENT_TOPIC: &str =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+/// Pre-flight check called at the start of every legacy routing test.
+/// Panics with a clear message if the cutoff block hasn't been minted or isn't empty.
+async fn assert_legacy_preconditions(client: &operations::HttpClient) {
+    let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
+
+    let current_block =
+        operations::eth_block_number(client).await.expect("Failed to get block number");
+    assert!(
+        current_block >= cutoff,
+        "Cutoff block {cutoff} has not been minted yet (current: {current_block})"
+    );
+
+    let block = operations::eth_get_block_by_number_or_hash(
+        client,
+        operations::BlockId::Number(cutoff),
+        false,
+    )
+    .await
+    .expect("Failed to get cutoff block");
+
+    let txs = block["transactions"].as_array().expect("Block should have transactions array");
+    assert!(
+        txs.len() <= 1,
+        "Cutoff block {cutoff} should be empty (at most 1 L1 attributes tx), got {} txs",
+        txs.len()
+    );
+}
+
+/// Tests `eth_getLogs` legacy routing for all three `eth_getLogs` code paths:
+/// blockHash filter, range routing (pure local / pure legacy / hybrid split).
+#[rstest::rstest]
+#[case::block_hash_with_logs("BlockHashWithLogs")]
+#[case::block_hash_empty_result_regression("BlockHashEmptyResultRegression")]
+#[case::range_pure_local("RangePureLocal")]
+#[case::range_pure_legacy("RangePureLegacy")]
+#[case::range_hybrid("RangeHybrid")]
+#[tokio::test]
+async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
+    let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
+    assert_legacy_preconditions(&client).await;
+    let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
+
+    match test_name {
+        "BlockHashWithLogs" => {
+            // Baseline: blockHash filter on a block WITH logs returns them locally.
+            let contracts =
+                operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
+            let erc20_address = format!("{:#x}", contracts.erc20);
+
+            let (_tx_hashes, block_number, block_hash) = operations::transfer_erc20_token_batch(
+                operations::manager::DEFAULT_L2_NETWORK_URL,
+                contracts.erc20,
+                U256::from(100 * operations::ETH_WEI),
+                operations::manager::DEFAULT_L2_NEW_ACC1_ADDRESS,
+                1,
+            )
+            .await
+            .expect("Failed to perform ERC20 transfer");
+
+            operations::wait_for_blocks(&client, block_number).await;
+
+            let logs = operations::eth_get_logs_by_block_hash(
+                &client,
+                &block_hash,
+                Some(&erc20_address),
+                Some(vec![TRANSFER_EVENT_TOPIC.to_string()]),
+            )
+            .await
+            .expect("Failed to get logs by block hash");
+
+            let logs_arr = logs.as_array().expect("Logs should be an array");
+            assert!(!logs_arr.is_empty(), "Should have at least one Transfer log");
+
+            for log in logs_arr {
+                assert_eq!(
+                    log["blockHash"].as_str().unwrap().to_lowercase(),
+                    block_hash.to_lowercase(),
+                );
+                assert_eq!(
+                    log["address"].as_str().unwrap().to_lowercase(),
+                    erc20_address.to_lowercase(),
+                );
+            }
+
+            println!("BlockHashWithLogs: {} logs in block {block_hash}", logs_arr.len());
+        }
+        "BlockHashEmptyResultRegression" => {
+            // REGRESSION TEST: blockHash filter on a block with NO matching logs
+            // must return [] locally, NOT forward to legacy and error out.
+            let tx_hash = operations::native_balance_transfer(
+                operations::manager::DEFAULT_L2_NETWORK_URL,
+                U256::from(1_000_000_000u64),
+                operations::manager::DEFAULT_L2_NEW_ACC1_ADDRESS,
+                None,
+                true,
+            )
+            .await
+            .expect("Failed to send ETH transfer");
+
+            let receipt = operations::eth_get_transaction_receipt(&client, &tx_hash)
+                .await
+                .expect("Failed to get receipt");
+            let block_hash =
+                receipt["blockHash"].as_str().expect("Receipt should have blockHash").to_string();
+
+            // Query an address with no logs in this block
+            let logs = operations::eth_get_logs_by_block_hash(
+                &client,
+                &block_hash,
+                Some("0x0000000000000000000000000000000000000001"),
+                None,
+            )
+            .await
+            .expect("eth_getLogs with blockHash should succeed even when no logs match");
+
+            let logs_arr = logs.as_array().expect("Result should be an array");
+            assert!(logs_arr.is_empty(), "Should return [], got {} logs", logs_arr.len());
+
+            println!("BlockHashEmptyResultRegression: correctly returned [] for {block_hash}");
+        }
+        "RangePureLocal" => {
+            // Both bounds >= cutoff — served locally, not forwarded
+            let current_block =
+                operations::eth_block_number(&client).await.expect("Failed to get block number");
+            let from = current_block.saturating_sub(5);
+
+            let logs = operations::eth_get_logs(
+                &client,
+                Some(operations::BlockId::Number(from)),
+                Some(operations::BlockId::Number(current_block)),
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to get logs for pure local range");
+
+            assert!(logs.is_array(), "Result should be an array");
+            println!(
+                "RangePureLocal: {} logs for blocks {from}..{current_block}",
+                logs.as_array().unwrap().len()
+            );
+        }
+        "RangePureLegacy" => {
+            // Both bounds < cutoff — forwarded entirely to legacy
+            let genesis = operations::manager::DEVNET_GENESIS_BLOCK;
+            let logs = operations::eth_get_logs(
+                &client,
+                Some(operations::BlockId::Number(genesis)),
+                Some(operations::BlockId::Number(cutoff - 1)),
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to get logs for pure legacy range");
+
+            let logs_arr = logs.as_array().expect("Result should be an array");
+            for log in logs_arr {
+                if let Some(bn_str) = log["blockNumber"].as_str() {
+                    let bn = u64::from_str_radix(bn_str.trim_start_matches("0x"), 16).unwrap_or(0);
+                    assert!(bn < cutoff, "Log blockNumber {bn} should be below cutoff {cutoff}");
+                }
+            }
+
+            println!("RangePureLegacy: {} logs below cutoff {cutoff}", logs_arr.len());
+        }
+        "RangeHybrid" => {
+            // Range spans cutoff — split into legacy + local, results merged
+            let genesis = operations::manager::DEVNET_GENESIS_BLOCK;
+            let current_block =
+                operations::eth_block_number(&client).await.expect("Failed to get block number");
+            let to = std::cmp::min(cutoff + 10, current_block);
+
+            let logs = operations::eth_get_logs(
+                &client,
+                Some(operations::BlockId::Number(genesis)),
+                Some(operations::BlockId::Number(to)),
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to get logs for hybrid range");
+
+            let logs_arr = logs.as_array().expect("Result should be an array");
+
+            // Verify logs are sorted by block number (merge correctness)
+            let mut prev_block: u64 = 0;
+            for log in logs_arr {
+                if let Some(bn_str) = log["blockNumber"].as_str() {
+                    let bn = u64::from_str_radix(bn_str.trim_start_matches("0x"), 16).unwrap_or(0);
+                    assert!(bn >= prev_block, "Logs not sorted: {bn} < {prev_block}");
+                    prev_block = bn;
+                }
+            }
+
+            println!(
+                "RangeHybrid: {} logs spanning cutoff (blocks {genesis}..{to})",
+                logs_arr.len()
+            );
+        }
+        _ => panic!("Unknown test case: {test_name}"),
+    }
+}
+
+/// Tests that `eth_getBlockByNumber` correctly forwards to legacy for blocks
+/// below the cutoff height, proving the block-param routing path works.
+#[tokio::test]
+async fn test_legacy_get_block_by_number_forwarding() {
+    let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
+    assert_legacy_preconditions(&client).await;
+    let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
+
+    // Below cutoff — should be forwarded to legacy endpoint
+    let block = operations::eth_get_block_by_number_or_hash(
+        &client,
+        operations::BlockId::Number(cutoff - 1),
+        false,
+    )
+    .await
+    .expect("Failed to get block below cutoff via legacy");
+
+    assert!(!block.is_null(), "Legacy block should not be null");
+    assert!(block["hash"].is_string(), "Legacy block should have hash");
+
+    let block_num_str = block["number"].as_str().expect("Block should have number");
+    let block_num = u64::from_str_radix(block_num_str.trim_start_matches("0x"), 16)
+        .expect("Should parse block number");
+    assert_eq!(block_num, cutoff - 1, "Block number should match requested");
+
+    println!("Legacy forwarding OK: block #{block_num} retrieved via legacy endpoint");
+}

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -630,16 +630,15 @@ async fn test_eth_get_logs_by_block_hash() {
     .await
     .expect("eth_getLogs by blockHash must succeed even when the block has no matching events");
 
-    assert!(
-        empty_logs.is_array(),
-        "Result must be a JSON array, not an error. Got: {empty_logs}"
-    );
+    assert!(empty_logs.is_array(), "Result must be a JSON array, not an error. Got: {empty_logs}");
     assert_eq!(
         empty_logs.as_array().unwrap().len(),
         0,
         "Expected empty array for non-existent address filter, got: {empty_logs}"
     );
-    println!("Case 1 passed: locally-known block with no matching events → [] (not 'block not found')");
+    println!(
+        "Case 1 passed: locally-known block with no matching events → [] (not 'block not found')"
+    );
 
     // ── Case 2: block exists locally with ERC20 Transfer events ─────────────
     let contracts = operations::try_deploy_contracts().await.expect("Failed to deploy contracts");

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -1017,54 +1017,53 @@ async fn test_new_transaction_types(#[case] test_name: &str) {
 // JSON-RPC calls and routes them to either the local reth node or a legacy
 // endpoint based on block height cutoffs.
 //
-// The devnet must be started with `--rpc.legacy-url` and
-// `--rpc.legacy-cutoff-override=8593925` on the RPC node.
+// On devnet the legacy endpoint points to L1 geth (`--rpc.legacy-url=http://l1-geth:8545`)
+// and the cutoff defaults to the L2 genesis block (8593921). Any request for a
+// block below genesis is forwarded to L1 geth.
 
 /// ERC20 Transfer event topic: `keccak256("Transfer(address,address,uint256)")`
 const TRANSFER_EVENT_TOPIC: &str =
     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
 
-/// Pre-flight check called at the start of every legacy routing test.
-/// Panics with a clear message if the cutoff block hasn't been minted or isn't empty.
-async fn assert_legacy_preconditions(client: &operations::HttpClient) {
-    let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
+/// Returns the current L1 block height by querying the L1 node directly.
+async fn get_l1_block_height() -> u64 {
+    let l1_client = operations::create_test_client(operations::manager::DEFAULT_L1_NETWORK_URL);
+    operations::eth_block_number(&l1_client).await.expect("Failed to get L1 block number")
+}
 
-    let current_block =
-        operations::eth_block_number(client).await.expect("Failed to get block number");
+/// Pre-flight check called at the start of every legacy routing test.
+/// Verifies that L1 height is below L2 genesis (so forwarded requests land in
+/// L1's valid block range) and that L2 has minted past genesis.
+async fn assert_legacy_preconditions(client: &operations::HttpClient) {
+    let genesis = operations::manager::DEVNET_GENESIS_BLOCK;
+
+    // L2 must have minted past genesis
+    let l2_height =
+        operations::eth_block_number(client).await.expect("Failed to get L2 block number");
     assert!(
-        current_block >= cutoff,
-        "Cutoff block {cutoff} has not been minted yet (current: {current_block})"
+        l2_height >= genesis,
+        "L2 genesis block {genesis} not minted yet (current L2: {l2_height})"
     );
 
-    let block = operations::eth_get_block_by_number_or_hash(
-        client,
-        operations::BlockId::Number(cutoff),
-        false,
-    )
-    .await
-    .expect("Failed to get cutoff block");
-
-    let txs = block["transactions"].as_array().expect("Block should have transactions array");
+    // L1 height must be below L2 genesis — otherwise L1 block numbers overlap
+    // with L2 local blocks and the forwarding boundary becomes ambiguous.
+    let l1_height = get_l1_block_height().await;
     assert!(
-        txs.len() <= 1,
-        "Cutoff block {cutoff} should be empty (at most 1 L1 attributes tx), got {} txs",
-        txs.len()
+        l1_height < genesis,
+        "L1 height ({l1_height}) must be below L2 genesis ({genesis}) for legacy routing tests"
     );
 }
 
-/// Tests `eth_getLogs` legacy routing for all three `eth_getLogs` code paths:
-/// blockHash filter, range routing (pure local / pure legacy / hybrid split).
+/// Tests `eth_getLogs` legacy routing for blockHash filter and range routing.
 #[rstest::rstest]
 #[case::block_hash_with_logs("BlockHashWithLogs")]
 #[case::block_hash_empty_result_regression("BlockHashEmptyResultRegression")]
 #[case::range_pure_local("RangePureLocal")]
 #[case::range_pure_legacy("RangePureLegacy")]
-#[case::range_hybrid("RangeHybrid")]
 #[tokio::test]
 async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
     let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
     assert_legacy_preconditions(&client).await;
-    let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
 
     match test_name {
         "BlockHashWithLogs" => {
@@ -1129,7 +1128,6 @@ async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
             let block_hash =
                 receipt["blockHash"].as_str().expect("Receipt should have blockHash").to_string();
 
-            // Query an address with no logs in this block
             let logs = operations::eth_get_logs_by_block_hash(
                 &client,
                 &block_hash,
@@ -1145,7 +1143,7 @@ async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
             println!("BlockHashEmptyResultRegression: correctly returned [] for {block_hash}");
         }
         "RangePureLocal" => {
-            // Both bounds >= cutoff — served locally, not forwarded
+            // Both bounds >= genesis (cutoff) — served locally, not forwarded
             let current_block =
                 operations::eth_block_number(&client).await.expect("Failed to get block number");
             let from = current_block.saturating_sub(5);
@@ -1167,91 +1165,56 @@ async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
             );
         }
         "RangePureLegacy" => {
-            // Both bounds < cutoff — forwarded entirely to legacy
-            let genesis = operations::manager::DEVNET_GENESIS_BLOCK;
+            // Both bounds < genesis (cutoff) — forwarded entirely to L1 via legacy
+            let l1_height = get_l1_block_height().await;
+            let from = l1_height.saturating_sub(10);
+
             let logs = operations::eth_get_logs(
                 &client,
-                Some(operations::BlockId::Number(genesis)),
-                Some(operations::BlockId::Number(cutoff - 1)),
+                Some(operations::BlockId::Number(from)),
+                Some(operations::BlockId::Number(l1_height)),
                 None,
                 None,
             )
             .await
-            .expect("Failed to get logs for pure legacy range");
+            .expect("Failed to get logs for pure legacy range (forwarded to L1)");
 
-            let logs_arr = logs.as_array().expect("Result should be an array");
-            for log in logs_arr {
-                if let Some(bn_str) = log["blockNumber"].as_str() {
-                    let bn = u64::from_str_radix(bn_str.trim_start_matches("0x"), 16).unwrap_or(0);
-                    assert!(bn < cutoff, "Log blockNumber {bn} should be below cutoff {cutoff}");
-                }
-            }
-
-            println!("RangePureLegacy: {} logs below cutoff {cutoff}", logs_arr.len());
-        }
-        "RangeHybrid" => {
-            // Range spans cutoff — split into legacy + local, results merged
-            let genesis = operations::manager::DEVNET_GENESIS_BLOCK;
-            let current_block =
-                operations::eth_block_number(&client).await.expect("Failed to get block number");
-            let to = std::cmp::min(cutoff + 10, current_block);
-
-            let logs = operations::eth_get_logs(
-                &client,
-                Some(operations::BlockId::Number(genesis)),
-                Some(operations::BlockId::Number(to)),
-                None,
-                None,
-            )
-            .await
-            .expect("Failed to get logs for hybrid range");
-
-            let logs_arr = logs.as_array().expect("Result should be an array");
-
-            // Verify logs are sorted by block number (merge correctness)
-            let mut prev_block: u64 = 0;
-            for log in logs_arr {
-                if let Some(bn_str) = log["blockNumber"].as_str() {
-                    let bn = u64::from_str_radix(bn_str.trim_start_matches("0x"), 16).unwrap_or(0);
-                    assert!(bn >= prev_block, "Logs not sorted: {bn} < {prev_block}");
-                    prev_block = bn;
-                }
-            }
-
+            assert!(logs.is_array(), "Result should be an array");
             println!(
-                "RangeHybrid: {} logs spanning cutoff (blocks {genesis}..{to})",
-                logs_arr.len()
+                "RangePureLegacy: {} logs from L1 blocks {from}..{l1_height}",
+                logs.as_array().unwrap().len()
             );
         }
         _ => panic!("Unknown test case: {test_name}"),
     }
 }
 
-/// Tests that `eth_getBlockByNumber` correctly forwards to legacy for blocks
-/// below the cutoff height. Local routing (>= cutoff) is already covered by
-/// the existing `test_eth_block_rpc::EthGetBlockByNumber` test.
+/// Tests that `eth_getBlockByNumber` correctly forwards to L1 for blocks
+/// below the cutoff (genesis) height.
 #[tokio::test]
 async fn test_legacy_get_block_by_number_forwarding() {
     let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
     assert_legacy_preconditions(&client).await;
-    let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
 
-    // Below cutoff — should be forwarded to legacy endpoint
+    // Get L1's current height, then request that block through the L2 RPC.
+    // The legacy routing layer should forward it to L1.
+    let l1_height = get_l1_block_height().await;
+
     let block = operations::eth_get_block_by_number_or_hash(
         &client,
-        operations::BlockId::Number(cutoff - 1),
+        operations::BlockId::Number(l1_height),
         false,
     )
     .await
-    .expect("Failed to get block below cutoff via legacy");
+    .expect("Failed to get L1 block via legacy forwarding");
 
-    assert!(!block.is_null(), "Legacy block should not be null");
-    assert!(block["hash"].is_string(), "Legacy block should have hash");
+    assert!(!block.is_null(), "Forwarded block should not be null");
+    assert!(block["hash"].is_string(), "Forwarded block should have hash");
 
     let block_num_str = block["number"].as_str().expect("Block should have number");
     let block_num = u64::from_str_radix(block_num_str.trim_start_matches("0x"), 16)
         .expect("Should parse block number");
-    assert_eq!(block_num, cutoff - 1, "Block number should match requested");
+    assert_eq!(block_num, l1_height, "Block number should match requested L1 height");
 
-    println!("Legacy forwarding OK: block #{block_num} retrieved via legacy endpoint");
+    println!("Legacy forwarding OK: L1 block #{block_num} retrieved via L2 RPC");
 }

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -1227,16 +1227,17 @@ async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
     }
 }
 
-/// Tests `eth_getBlockByNumber` routing at the cutoff boundary:
-/// blocks below cutoff are forwarded to legacy, blocks at cutoff are served locally.
+/// Tests that `eth_getBlockByNumber` correctly forwards to legacy for blocks
+/// below the cutoff height. Local routing (>= cutoff) is already covered by
+/// the existing `test_eth_block_rpc::EthGetBlockByNumber` test.
 #[tokio::test]
-async fn test_legacy_get_block_by_number_routing() {
+async fn test_legacy_get_block_by_number_forwarding() {
     let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
     assert_legacy_preconditions(&client).await;
     let cutoff = operations::manager::LEGACY_CUTOFF_BLOCK_HEIGHT;
 
-    // Below cutoff — forwarded to legacy endpoint
-    let legacy_block = operations::eth_get_block_by_number_or_hash(
+    // Below cutoff — should be forwarded to legacy endpoint
+    let block = operations::eth_get_block_by_number_or_hash(
         &client,
         operations::BlockId::Number(cutoff - 1),
         false,
@@ -1244,26 +1245,13 @@ async fn test_legacy_get_block_by_number_routing() {
     .await
     .expect("Failed to get block below cutoff via legacy");
 
-    assert!(!legacy_block.is_null(), "Legacy block should not be null");
-    let legacy_num_str = legacy_block["number"].as_str().expect("Block should have number");
-    let legacy_num = u64::from_str_radix(legacy_num_str.trim_start_matches("0x"), 16)
-        .expect("Should parse block number");
-    assert_eq!(legacy_num, cutoff - 1, "Block number should match requested");
-    println!("Below cutoff: block #{legacy_num} retrieved via legacy");
+    assert!(!block.is_null(), "Legacy block should not be null");
+    assert!(block["hash"].is_string(), "Legacy block should have hash");
 
-    // At cutoff — served locally (>= cutoff is local)
-    let local_block = operations::eth_get_block_by_number_or_hash(
-        &client,
-        operations::BlockId::Number(cutoff),
-        false,
-    )
-    .await
-    .expect("Failed to get block at cutoff from local node");
-
-    assert!(!local_block.is_null(), "Local block should not be null");
-    let local_num_str = local_block["number"].as_str().expect("Block should have number");
-    let local_num = u64::from_str_radix(local_num_str.trim_start_matches("0x"), 16)
+    let block_num_str = block["number"].as_str().expect("Block should have number");
+    let block_num = u64::from_str_radix(block_num_str.trim_start_matches("0x"), 16)
         .expect("Should parse block number");
-    assert_eq!(local_num, cutoff, "Block number should match requested");
-    println!("At cutoff: block #{local_num} served locally");
+    assert_eq!(block_num, cutoff - 1, "Block number should match requested");
+
+    println!("Legacy forwarding OK: block #{block_num} retrieved via legacy endpoint");
 }

--- a/crates/tests/operations/manager.rs
+++ b/crates/tests/operations/manager.rs
@@ -68,3 +68,10 @@ pub const DEFAULT_OK_PAY_SENDER_ADDRESS: &str = "0xa0Ee7A142d267C1f36714E4a8F756
 /// Default OkPay sender private key for testing
 pub const DEFAULT_OK_PAY_SENDER_PRIVATE_KEY: &str =
     "2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6";
+
+// Legacy RPC Configuration
+/// Devnet genesis block number. No blocks exist below this height.
+pub const DEVNET_GENESIS_BLOCK: u64 = 8593921;
+/// The cutoff block height for legacy routing override on devnet.
+/// All blocks below this number are forwarded to legacy; blocks >= this are local.
+pub const LEGACY_CUTOFF_BLOCK_HEIGHT: u64 = 8593925;

--- a/crates/tests/operations/manager.rs
+++ b/crates/tests/operations/manager.rs
@@ -70,8 +70,6 @@ pub const DEFAULT_OK_PAY_SENDER_PRIVATE_KEY: &str =
     "2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6";
 
 // Legacy RPC Configuration
-/// Devnet genesis block number. No blocks exist below this height.
+/// Devnet L2 genesis block number. The legacy RPC cutoff defaults to this value.
+/// Blocks below genesis are forwarded to the legacy endpoint (L1 geth on devnet).
 pub const DEVNET_GENESIS_BLOCK: u64 = 8593921;
-/// The cutoff block height for legacy routing override on devnet.
-/// All blocks below this number are forwarded to legacy; blocks >= this are local.
-pub const LEGACY_CUTOFF_BLOCK_HEIGHT: u64 = 8593925;


### PR DESCRIPTION
## Summary

1. Add e2e test coverage for the `LegacyRpcRouterLayer` middleware, which routes JSON-RPC calls to either the local reth node or a legacy endpoint based on block height cutoffs.
2. On devnet, the legacy endpoint points to L1 geth (`--rpc.legacy-url=http://l1-geth:8545`). The cutoff defaults to the L2 genesis block (8593921) — any request for a block below genesis is forwarded to L1.

### Tests added

| Test | What it verifies |
|------|-----------------|
| `test_legacy_eth_get_logs::BlockHashWithLogs` | blockHash filter returns logs locally for blocks above genesis |
| `test_legacy_eth_get_logs::BlockHashEmptyResultRegression` | **Regression test** — empty `[]` returned locally, not forwarded to legacy |
| `test_legacy_eth_get_logs::RangePureLocal` | Range >= genesis served locally |
| `test_legacy_eth_get_logs::RangePureLegacy` | Range within L1 block heights forwarded to L1 via legacy |
| `test_legacy_get_block_by_number_forwarding` | `eth_getBlockByNumber` with L1 block height forwarded correctly |

### Preconditions validated before each test
- L2 has minted past genesis block
- L1 height is below L2 genesis (no block number overlap)

Depends on devnet config: https://github.com/okx/xlayer-toolkit/pull/151

## Test plan

- [ ] Run legacy e2e tests with devnet configured with `--rpc.legacy-url=http://l1-geth:8545`
- [ ] Verify `BlockHashEmptyResultRegression` passes (after `get_logs.rs` fix is applied)
- [ ] Verify range routing (pure local, pure legacy) succeeds
- [ ] Verify `eth_getBlockByNumber` forwarding returns L1 block data

🤖 Generated with [Claude Code](https://claude.com/claude-code)