### PR TITLE
fix(legacy-rpc): eth_getLogs by blockHash returns empty array for local blocks with no matching events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ crates/chainspec/res/genesis/xlayer-devnet-state-root.txt
 
 # Local development: cargo config for debugging with local reth
 .cargo
+.omc

--- a/bin/node/src/args.rs
+++ b/bin/node/src/args.rs
@@ -111,7 +111,6 @@ impl XLayerInterceptArgs {
         Ok(())
     }
 }
-
 /// X Layer specific configuration flags
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "X Layer")]

--- a/crates/legacy-rpc/src/get_logs.rs
+++ b/crates/legacy-rpc/src/get_logs.rs
@@ -359,8 +359,7 @@ mod tests {
             };
             Box::pin(async move {
                 let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
-                let result =
-                    json.get("result").cloned().unwrap_or(serde_json::Value::Null);
+                let result = json.get("result").cloned().unwrap_or(serde_json::Value::Null);
                 let payload = jsonrpsee_types::ResponsePayload::success(&result).into();
                 MethodResponse::response(Id::Number(1), payload, usize::MAX)
             })

--- a/crates/legacy-rpc/src/get_logs.rs
+++ b/crates/legacy-rpc/src/get_logs.rs
@@ -300,9 +300,15 @@ where
                     debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, block exists locally, using local result");
                     inner.call(req).await
                 }
-                Ok(None) | Err(_) => {
+                Ok(None) => {
                     // Block not found locally; forward to legacy
                     debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, block not found locally, forward to legacy");
+                    service.forward_to_legacy(req).await
+                }
+                Err(e) => {
+                    // Unexpected error — hash was already validated upstream so this
+                    // should be unreachable, but log it to make any surprise visible.
+                    debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, unexpected error checking block by hash ({e}), forward to legacy");
                     service.forward_to_legacy(req).await
                 }
             }

--- a/crates/legacy-rpc/src/get_logs.rs
+++ b/crates/legacy-rpc/src/get_logs.rs
@@ -24,7 +24,7 @@
 //!     These get converted to 0
 //! to_block: latest/pending/finalized/safe
 //!     These get converted to u64::MAX
-use crate::{service::is_result_empty, LegacyRpcRouterService};
+use crate::LegacyRpcRouterService;
 use jsonrpsee::{
     types::{error::INVALID_PARAMS_CODE, ErrorObject},
     MethodResponse,
@@ -292,15 +292,19 @@ where
                 return inner.call(req).await;
             }
         }
-        Some(GetLogsParams::BlockHash(_block_hash)) => {
-            debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, testing locally first...");
-            let res = inner.call(req.clone()).await;
-            if res.is_success() && !is_result_empty(&res) {
-                debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, success response = {res:?}");
-                res
-            } else {
-                debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, forward to legacy (empty or error)");
-                service.forward_to_legacy(req).await
+        Some(GetLogsParams::BlockHash(block_hash)) => {
+            debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, checking if block exists locally...");
+            match service.call_eth_get_block_by_hash(&block_hash, false).await {
+                Ok(Some(_)) => {
+                    // Block exists locally; return local result even if logs are empty
+                    debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, block exists locally, using local result");
+                    inner.call(req).await
+                }
+                Ok(None) | Err(_) => {
+                    // Block not found locally; forward to legacy
+                    debug!(target:"xlayer_legacy_rpc", "method = eth_getLogs, block not found locally, forward to legacy");
+                    service.forward_to_legacy(req).await
+                }
             }
         }
         _ => {
@@ -313,9 +317,172 @@ where
 #[cfg(test)]
 mod tests {
     use crate::get_logs::GetLogsParams;
+    use crate::LegacyRpcRouterConfig;
+    use jsonrpsee::core::middleware::RpcServiceT;
     use jsonrpsee::MethodResponse;
     use jsonrpsee_types::{Id, Request};
     use serde_json::value::RawValue;
+    use std::future::Future;
+    use std::sync::Arc;
+
+    // ── Shared helpers for BlockHash routing tests ─────────────────────────────
+
+    const TEST_BLOCK_HASH: &str =
+        "0x8c83240f457f709b4574dd57afb656242418ea481325ea3c284c4ba144c1e032";
+
+    /// Mock that returns different responses for `eth_getBlockByHash` vs everything else.
+    #[derive(Clone)]
+    struct MockRpcService {
+        block_response: String,
+        other_response: String,
+    }
+
+    impl RpcServiceT for MockRpcService {
+        type MethodResponse = MethodResponse;
+        type NotificationResponse = MethodResponse;
+        type BatchResponse = Vec<MethodResponse>;
+
+        fn call<'a>(
+            &self,
+            req: Request<'a>,
+        ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+            let json_str = if req.method_name() == "eth_getBlockByHash" {
+                self.block_response.clone()
+            } else {
+                self.other_response.clone()
+            };
+            Box::pin(async move {
+                let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+                let result =
+                    json.get("result").cloned().unwrap_or(serde_json::Value::Null);
+                let payload = jsonrpsee_types::ResponsePayload::success(&result).into();
+                MethodResponse::response(Id::Number(1), payload, usize::MAX)
+            })
+        }
+
+        fn batch<'a>(
+            &self,
+            _req: jsonrpsee::core::middleware::Batch<'a>,
+        ) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+            Box::pin(async { vec![] })
+        }
+
+        fn notification<'a>(
+            &self,
+            _n: jsonrpsee::core::middleware::Notification<'a>,
+        ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+            Box::pin(async {
+                MethodResponse::error(
+                    Id::Number(1),
+                    jsonrpsee::types::ErrorObjectOwned::owned(
+                        -32600,
+                        "Not implemented",
+                        None::<()>,
+                    ),
+                )
+            })
+        }
+    }
+
+    fn make_get_logs_by_hash_request(block_hash: &str) -> Request<'static> {
+        let params = format!(r#"[{{"blockHash":"{block_hash}"}}]"#);
+        let params_raw = RawValue::from_string(params).unwrap();
+        Request::owned("eth_getLogs".to_string(), Some(params_raw), Id::Number(1))
+    }
+
+    fn make_test_config() -> Arc<LegacyRpcRouterConfig> {
+        Arc::new(LegacyRpcRouterConfig {
+            enabled: true,
+            // Unreachable endpoint: any forward attempt produces a clear error response.
+            legacy_endpoint: "http://127.0.0.1:1".to_string(),
+            cutoff_block: 1_000_000,
+            timeout: std::time::Duration::from_secs(1),
+        })
+    }
+
+    // ── BlockHash routing tests ────────────────────────────────────────────────
+
+    /// Regression test for the original bug:
+    ///
+    /// Block exists locally but has zero events. The old code checked
+    /// `is_result_empty` and forwarded to legacy, which returned "block not
+    /// found". The fix checks block existence first; an empty log array from a
+    /// known-local block is returned directly.
+    #[tokio::test]
+    async fn test_block_hash_block_exists_with_empty_logs_returns_local_empty() {
+        let mock = MockRpcService {
+            block_response: r#"{"jsonrpc":"2.0","id":1,"result":{"number":"0xf4240","hash":"0x8c83240f457f709b4574dd57afb656242418ea481325ea3c284c4ba144c1e032"}}"#.into(),
+            other_response: r#"{"jsonrpc":"2.0","id":1,"result":[]}"#.into(),
+        };
+
+        let response = super::handle_eth_get_logs(
+            make_get_logs_by_hash_request(TEST_BLOCK_HASH),
+            reqwest::Client::new(),
+            make_test_config(),
+            mock,
+        )
+        .await;
+
+        assert!(response.is_success(), "expected success, got: {}", response.as_json().get());
+        let json: serde_json::Value = serde_json::from_str(response.as_json().get()).unwrap();
+        let result = json.get("result").expect("response must have result field");
+        assert!(result.is_array(), "result must be an array");
+        assert_eq!(
+            result.as_array().unwrap().len(),
+            0,
+            "should return local empty array, not forward to legacy"
+        );
+    }
+
+    /// Block exists locally and has events — local logs are returned directly.
+    #[tokio::test]
+    async fn test_block_hash_block_exists_with_logs_returns_local_logs() {
+        let mock = MockRpcService {
+            block_response: r#"{"jsonrpc":"2.0","id":1,"result":{"number":"0xf4240","hash":"0x8c83240f457f709b4574dd57afb656242418ea481325ea3c284c4ba144c1e032"}}"#.into(),
+            other_response: r#"{"jsonrpc":"2.0","id":1,"result":[{"address":"0x1234567890123456789012345678901234567890","blockNumber":"0xf4240","logIndex":"0x0"}]}"#.into(),
+        };
+
+        let response = super::handle_eth_get_logs(
+            make_get_logs_by_hash_request(TEST_BLOCK_HASH),
+            reqwest::Client::new(),
+            make_test_config(),
+            mock,
+        )
+        .await;
+
+        assert!(response.is_success());
+        let json: serde_json::Value = serde_json::from_str(response.as_json().get()).unwrap();
+        let result = json.get("result").unwrap().as_array().unwrap();
+        assert_eq!(result.len(), 1, "should return the one log from local node");
+    }
+
+    /// Block is not found locally — request is forwarded to legacy.
+    ///
+    /// The legacy endpoint is unreachable in tests, so a forwarded request
+    /// produces an error response. An error here confirms the forward path was
+    /// taken (the local path would have returned a success).
+    #[tokio::test]
+    async fn test_block_hash_block_not_found_locally_forwards_to_legacy() {
+        let mock = MockRpcService {
+            block_response: r#"{"jsonrpc":"2.0","id":1,"result":null}"#.into(),
+            // If routing incorrectly hits local for getLogs, it would return success.
+            other_response: r#"{"jsonrpc":"2.0","id":1,"result":[]}"#.into(),
+        };
+
+        let response = super::handle_eth_get_logs(
+            make_get_logs_by_hash_request(TEST_BLOCK_HASH),
+            reqwest::Client::new(),
+            make_test_config(),
+            mock,
+        )
+        .await;
+
+        assert!(
+            response.is_error(),
+            "expected forward-to-legacy error when block not found locally, got: {}",
+            response.as_json().get()
+        );
+    }
 
     #[test]
     fn test_parse_eth_get_logs_params_both_blocks() {

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -630,16 +630,15 @@ async fn test_eth_get_logs_by_block_hash() {
     .await
     .expect("eth_getLogs by blockHash must succeed even when the block has no matching events");
 
-    assert!(
-        empty_logs.is_array(),
-        "Result must be a JSON array, not an error. Got: {empty_logs}"
-    );
+    assert!(empty_logs.is_array(), "Result must be a JSON array, not an error. Got: {empty_logs}");
     assert_eq!(
         empty_logs.as_array().unwrap().len(),
         0,
         "Expected empty array for non-existent address filter, got: {empty_logs}"
     );
-    println!("Case 1 passed: locally-known block with no matching events → [] (not 'block not found')");
+    println!(
+        "Case 1 passed: locally-known block with no matching events → [] (not 'block not found')"
+    );
 
     // ── Case 2: block exists locally with ERC20 Transfer events ─────────────
     let contracts = operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
@@ -1092,4 +1091,214 @@ async fn test_new_transaction_types(#[case] test_name: &str) {
         }
         _ => panic!("Unknown test case: {test_name}"),
     }
+}
+
+// ============================================================================
+// Legacy RPC Routing Tests
+// ============================================================================
+//
+// These tests exercise the `LegacyRpcRouterLayer` middleware that intercepts
+// JSON-RPC calls and routes them to either the local reth node or a legacy
+// endpoint based on block height cutoffs.
+//
+// On devnet the legacy endpoint points to L1 geth (`--rpc.legacy-url=http://l1-geth:8545`)
+// and the cutoff defaults to the L2 genesis block (8593921). Any request for a
+// block below genesis is forwarded to L1 geth.
+
+/// ERC20 Transfer event topic: `keccak256("Transfer(address,address,uint256)")`
+const TRANSFER_EVENT_TOPIC: &str =
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+/// Returns the current L1 block height by querying the L1 node directly.
+async fn get_l1_block_height() -> u64 {
+    let l1_client = operations::create_test_client(operations::manager::DEFAULT_L1_NETWORK_URL);
+    operations::eth_block_number(&l1_client).await.expect("Failed to get L1 block number")
+}
+
+/// Pre-flight check called at the start of every legacy routing test.
+/// Verifies that L1 height is below L2 genesis (so forwarded requests land in
+/// L1's valid block range) and that L2 has minted past genesis.
+async fn assert_legacy_preconditions(client: &operations::HttpClient) {
+    let genesis = operations::manager::DEVNET_GENESIS_BLOCK;
+
+    // L2 must have minted past genesis
+    let l2_height =
+        operations::eth_block_number(client).await.expect("Failed to get L2 block number");
+    assert!(
+        l2_height >= genesis,
+        "L2 genesis block {genesis} not minted yet (current L2: {l2_height})"
+    );
+
+    // L1 height must be below L2 genesis — otherwise L1 block numbers overlap
+    // with L2 local blocks and the forwarding boundary becomes ambiguous.
+    let l1_height = get_l1_block_height().await;
+    assert!(
+        l1_height < genesis,
+        "L1 height ({l1_height}) must be below L2 genesis ({genesis}) for legacy routing tests"
+    );
+}
+
+/// Tests `eth_getLogs` legacy routing for blockHash filter and range routing.
+#[rstest::rstest]
+#[case::block_hash_with_logs("BlockHashWithLogs")]
+#[case::block_hash_empty_result_regression("BlockHashEmptyResultRegression")]
+#[case::range_pure_local("RangePureLocal")]
+#[case::range_pure_legacy("RangePureLegacy")]
+#[tokio::test]
+async fn test_legacy_eth_get_logs(#[case] test_name: &str) {
+    let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
+    assert_legacy_preconditions(&client).await;
+
+    match test_name {
+        "BlockHashWithLogs" => {
+            // Baseline: blockHash filter on a block WITH logs returns them locally.
+            let contracts =
+                operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
+            let erc20_address = format!("{:#x}", contracts.erc20);
+
+            let (_tx_hashes, block_number, block_hash) = operations::transfer_erc20_token_batch(
+                operations::manager::DEFAULT_L2_NETWORK_URL,
+                contracts.erc20,
+                U256::from(100 * operations::ETH_WEI),
+                operations::manager::DEFAULT_L2_NEW_ACC1_ADDRESS,
+                1,
+            )
+            .await
+            .expect("Failed to perform ERC20 transfer");
+
+            operations::wait_for_blocks(&client, block_number).await;
+
+            let logs = operations::eth_get_logs_by_block_hash(
+                &client,
+                &block_hash,
+                Some(&erc20_address),
+                Some(vec![TRANSFER_EVENT_TOPIC.to_string()]),
+            )
+            .await
+            .expect("Failed to get logs by block hash");
+
+            let logs_arr = logs.as_array().expect("Logs should be an array");
+            assert!(!logs_arr.is_empty(), "Should have at least one Transfer log");
+
+            for log in logs_arr {
+                assert_eq!(
+                    log["blockHash"].as_str().unwrap().to_lowercase(),
+                    block_hash.to_lowercase(),
+                );
+                assert_eq!(
+                    log["address"].as_str().unwrap().to_lowercase(),
+                    erc20_address.to_lowercase(),
+                );
+            }
+
+            println!("BlockHashWithLogs: {} logs in block {block_hash}", logs_arr.len());
+        }
+        "BlockHashEmptyResultRegression" => {
+            // REGRESSION TEST: blockHash filter on a block with NO matching logs
+            // must return [] locally, NOT forward to legacy and error out.
+            let tx_hash = operations::native_balance_transfer(
+                operations::manager::DEFAULT_L2_NETWORK_URL,
+                U256::from(1_000_000_000u64),
+                operations::manager::DEFAULT_L2_NEW_ACC1_ADDRESS,
+                None,
+                true,
+            )
+            .await
+            .expect("Failed to send ETH transfer");
+
+            let receipt = operations::eth_get_transaction_receipt(&client, &tx_hash)
+                .await
+                .expect("Failed to get receipt");
+            let block_hash =
+                receipt["blockHash"].as_str().expect("Receipt should have blockHash").to_string();
+
+            let logs = operations::eth_get_logs_by_block_hash(
+                &client,
+                &block_hash,
+                Some("0x0000000000000000000000000000000000000001"),
+                None,
+            )
+            .await
+            .expect("eth_getLogs with blockHash should succeed even when no logs match");
+
+            let logs_arr = logs.as_array().expect("Result should be an array");
+            assert!(logs_arr.is_empty(), "Should return [], got {} logs", logs_arr.len());
+
+            println!("BlockHashEmptyResultRegression: correctly returned [] for {block_hash}");
+        }
+        "RangePureLocal" => {
+            // Both bounds >= genesis (cutoff) — served locally, not forwarded
+            let current_block =
+                operations::eth_block_number(&client).await.expect("Failed to get block number");
+            let from = current_block.saturating_sub(5);
+
+            let logs = operations::eth_get_logs(
+                &client,
+                Some(operations::BlockId::Number(from)),
+                Some(operations::BlockId::Number(current_block)),
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to get logs for pure local range");
+
+            assert!(logs.is_array(), "Result should be an array");
+            println!(
+                "RangePureLocal: {} logs for blocks {from}..{current_block}",
+                logs.as_array().unwrap().len()
+            );
+        }
+        "RangePureLegacy" => {
+            // Both bounds < genesis (cutoff) — forwarded entirely to L1 via legacy
+            let l1_height = get_l1_block_height().await;
+            let from = l1_height.saturating_sub(10);
+
+            let logs = operations::eth_get_logs(
+                &client,
+                Some(operations::BlockId::Number(from)),
+                Some(operations::BlockId::Number(l1_height)),
+                None,
+                None,
+            )
+            .await
+            .expect("Failed to get logs for pure legacy range (forwarded to L1)");
+
+            assert!(logs.is_array(), "Result should be an array");
+            println!(
+                "RangePureLegacy: {} logs from L1 blocks {from}..{l1_height}",
+                logs.as_array().unwrap().len()
+            );
+        }
+        _ => panic!("Unknown test case: {test_name}"),
+    }
+}
+
+/// Tests that `eth_getBlockByNumber` correctly forwards to L1 for blocks
+/// below the cutoff (genesis) height.
+#[tokio::test]
+async fn test_legacy_get_block_by_number_forwarding() {
+    let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
+    assert_legacy_preconditions(&client).await;
+
+    // Get L1's current height, then request that block through the L2 RPC.
+    // The legacy routing layer should forward it to L1.
+    let l1_height = get_l1_block_height().await;
+
+    let block = operations::eth_get_block_by_number_or_hash(
+        &client,
+        operations::BlockId::Number(l1_height),
+        false,
+    )
+    .await
+    .expect("Failed to get L1 block via legacy forwarding");
+
+    assert!(!block.is_null(), "Forwarded block should not be null");
+    assert!(block["hash"].is_string(), "Forwarded block should have hash");
+
+    let block_num_str = block["number"].as_str().expect("Block should have number");
+    let block_num = u64::from_str_radix(block_num_str.trim_start_matches("0x"), 16)
+        .expect("Should parse block number");
+    assert_eq!(block_num, l1_height, "Block number should match requested L1 height");
+
+    println!("Legacy forwarding OK: L1 block #{block_num} retrieved via L2 RPC");
 }

--- a/crates/tests/e2e-tests/main.rs
+++ b/crates/tests/e2e-tests/main.rs
@@ -589,6 +589,91 @@ async fn test_eth_logs_rpc() {
     println!("EthGetLogs result type: {logs}");
 }
 
+/// Regression test for the `eth_getLogs` blockHash routing bug.
+///
+/// Before the fix, querying logs by block hash on a local block that had zero
+/// matching events caused the router to forward to legacy.  Legacy doesn't
+/// have the block and returns "block not found", which is wrong.
+///
+/// After the fix the router checks whether the block exists locally first:
+///   - Block found locally  → return local result (even if the log array is empty)
+///   - Block NOT found locally → forward to legacy
+///
+/// This test verifies both branches against a live node.
+#[tokio::test]
+async fn test_eth_get_logs_by_block_hash() {
+    let client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL);
+
+    // ── Case 1: block exists locally, no matching events ────────────────────
+    // Filter by an address that has never emitted logs so the result is [].
+    // Before the fix this triggered a legacy forward and returned "block not found".
+    let block_number = operations::wait_for_blocks(&client, 1).await;
+    let block = operations::eth_get_block_by_number_or_hash(
+        &client,
+        operations::BlockId::Number(block_number),
+        false,
+    )
+    .await
+    .expect("Failed to get local block");
+
+    let block_hash = block["hash"].as_str().expect("Block should have hash").to_string();
+    println!("Case 1 — block #{block_number}, hash: {block_hash}");
+
+    // 0xdead has no contract code and will never emit logs
+    let nonexistent_address = "0x000000000000000000000000000000000000dead";
+    let empty_logs = operations::eth_get_logs_by_block_hash(
+        &client,
+        &block_hash,
+        Some(nonexistent_address),
+        None,
+    )
+    .await
+    .expect("eth_getLogs by blockHash must succeed even when the block has no matching events");
+
+    assert!(
+        empty_logs.is_array(),
+        "Result must be a JSON array, not an error. Got: {empty_logs}"
+    );
+    assert_eq!(
+        empty_logs.as_array().unwrap().len(),
+        0,
+        "Expected empty array for non-existent address filter, got: {empty_logs}"
+    );
+    println!("Case 1 passed: locally-known block with no matching events → [] (not 'block not found')");
+
+    // ── Case 2: block exists locally with ERC20 Transfer events ─────────────
+    let contracts = operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
+
+    let (_tx_hashes, erc20_block_number, erc20_block_hash) =
+        operations::transfer_erc20_token_batch(
+            operations::manager::DEFAULT_L2_NETWORK_URL,
+            contracts.erc20,
+            U256::from(100u128 * operations::ETH_WEI),
+            operations::manager::DEFAULT_L2_NEW_ACC1_ADDRESS,
+            1,
+        )
+        .await
+        .expect("Failed to transfer ERC20 tokens");
+
+    operations::wait_for_blocks(&client, erc20_block_number).await;
+    println!("Case 2 — ERC20 transfer in block #{erc20_block_number}, hash: {erc20_block_hash}");
+
+    let logs_with_events =
+        operations::eth_get_logs_by_block_hash(&client, &erc20_block_hash, None, None)
+            .await
+            .expect("eth_getLogs by blockHash must succeed for a block with ERC20 events");
+
+    assert!(logs_with_events.is_array(), "Logs result must be a JSON array");
+    assert!(
+        !logs_with_events.as_array().unwrap().is_empty(),
+        "Expected at least one Transfer log in the ERC20 transfer block, got: {logs_with_events}"
+    );
+    println!(
+        "Case 2 passed: ERC20 transfer block returns {} log(s)",
+        logs_with_events.as_array().unwrap().len()
+    );
+}
+
 #[rstest::rstest]
 #[case::txpool_content("TxPoolContent")]
 #[case::txpool_status("TxPoolStatus")]

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -1948,11 +1948,16 @@ async fn fb_negative_test() {
         operations::eth_call(&fb_client, Some(call_args), Some(operations::BlockId::Pending)).await;
     assert!(result.is_err(), "eth_call with invalid selector should revert, got: {result:?}");
 
-    // eth_getRawTransactionByBlockNumberAndIndex with out-of-range index returns null
-    let result =
-        operations::eth_get_raw_transaction_by_block_number_and_index(&fb_client, "0x1", "0xFFFF")
-            .await
-            .expect("eth_getRawTransactionByBlockNumberAndIndex should not error for bad index");
+    // eth_getRawTransactionByBlockNumberAndIndex with out-of-range index returns null.
+    // Use an actual block that exists (latest), then query a tx index that doesn't exist.
+    let current_block =
+        operations::eth_block_number(&fb_client).await.expect("Failed to get block number");
+    let block_hex = format!("0x{current_block:x}");
+    let result = operations::eth_get_raw_transaction_by_block_number_and_index(
+        &fb_client, &block_hex, "0xFFFF",
+    )
+    .await
+    .expect("eth_getRawTransactionByBlockNumberAndIndex should not error for bad index");
     assert!(result.is_null(), "Out-of-range tx index should return null, got: {result}");
 }
 

--- a/crates/tests/operations/manager.rs
+++ b/crates/tests/operations/manager.rs
@@ -68,3 +68,8 @@ pub const DEFAULT_OK_PAY_SENDER_ADDRESS: &str = "0xa0Ee7A142d267C1f36714E4a8F756
 /// Default OkPay sender private key for testing
 pub const DEFAULT_OK_PAY_SENDER_PRIVATE_KEY: &str =
     "2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6";
+
+// Legacy RPC Configuration
+/// Devnet L2 genesis block number. The legacy RPC cutoff defaults to this value.
+/// Blocks below genesis are forwarded to the legacy endpoint (L1 geth on devnet).
+pub const DEVNET_GENESIS_BLOCK: u64 = 8593921;


### PR DESCRIPTION
Previously, querying eth_getLogs with a blockHash filter would forward to legacy if the local result was empty. This caused "block not found" errors when the block existed locally but had no matching events, since legacy doesn't hold those blocks.

Fix: check block existence via eth_getBlockByHash before deciding routing.
- Block found locally → return local result directly (even if logs are [])
- Block not found locally → forward to legacy

Also adds unit tests for all three routing branches and an e2e regression test covering both the empty-logs case and a block with ERC20 Transfer events.