### PR TITLE
feat(flashblocks-rpc): add support for eth_getHeaderByNumber and eth_getHeaderByHash

### DIFF
--- a/crates/rpc/src/eth.rs
+++ b/crates/rpc/src/eth.rs
@@ -1,5 +1,6 @@
 use crate::helper::{
-    to_block_receipts, to_rpc_block, to_rpc_transaction, to_rpc_transaction_from_bar_and_index,
+    to_block_receipts, to_rpc_block, to_rpc_header, to_rpc_transaction,
+    to_rpc_transaction_from_bar_and_index,
 };
 use futures::StreamExt;
 use jsonrpsee::{
@@ -28,7 +29,7 @@ use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_convert::{RpcConvert, RpcTransaction};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, FullEthApi, LoadState, SpawnBlocking},
-    EthApiServer, EthApiTypes, FromEvmError, RpcBlock, RpcNodeCore, RpcReceipt,
+    EthApiServer, EthApiTypes, FromEvmError, RpcBlock, RpcHeader, RpcNodeCore, RpcReceipt,
 };
 use reth_rpc_eth_types::{
     block::convert_transaction_receipt, EthApiError, RpcInvalidTransactionError,
@@ -62,6 +63,19 @@ pub trait FlashblocksEthApiOverride {
     /// and confirmed blocks.
     #[method(name = "getBlockByHash")]
     async fn block_by_hash(&self, hash: B256, full: bool) -> RpcResult<Option<RpcBlock<Optimism>>>;
+
+    /// Returns the block's header at given number, with the flashblock state cache overlay support
+    /// for pending and confirmed blocks.
+    #[method(name = "getHeaderByNumber")]
+    async fn header_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<RpcHeader<Optimism>>>;
+
+    /// Returns the block's header at given hash, with the flashblock state cache overlay support
+    /// for pending and confirmed blocks.
+    #[method(name = "getHeaderByHash")]
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<RpcHeader<Optimism>>>;
 
     /// Returns all the receipts in a block by block number, with the flashblock state cache
     /// overlay support for pending and confirmed blocks.
@@ -303,6 +317,27 @@ where
             return Ok(Some(U256::from(count)));
         }
         EthApiServer::block_transaction_count_by_hash(&self.eth_api, hash).await
+    }
+
+    /// Handler for: `eth_getHeaderByNumber`
+    async fn header_by_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<RpcHeader<Optimism>>> {
+        trace!(target: "rpc::eth", ?number, "Serving eth_getHeaderByNumber");
+        if let Some(bar) = self.flashblocks_state.get_rpc_block(number) {
+            return to_rpc_header(&bar, &self.converter).map(Some).map_err(Into::into);
+        }
+        EthApiServer::header_by_number(&self.eth_api, number).await
+    }
+
+    /// Handler for: `eth_getHeaderByHash`
+    async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<RpcHeader<Optimism>>> {
+        trace!(target: "rpc::eth", ?hash, "Serving eth_getHeaderByHash");
+        if let Some(bar) = self.flashblocks_state.get_block_by_hash(&hash) {
+            return to_rpc_header(&bar, &self.converter).map(Some).map_err(Into::into);
+        }
+        EthApiServer::header_by_hash(&self.eth_api, hash).await
     }
 
     // ----------------- Transaction apis -----------------

--- a/crates/rpc/src/helper.rs
+++ b/crates/rpc/src/helper.rs
@@ -6,7 +6,7 @@ use op_alloy_network::Optimism;
 use reth_optimism_primitives::OpPrimitives;
 use reth_primitives_traits::{Recovered, SignedTransaction, TransactionMeta};
 use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert, RpcTransaction};
-use reth_rpc_eth_api::{RpcBlock, RpcReceipt};
+use reth_rpc_eth_api::{RpcBlock, RpcHeader, RpcReceipt};
 use reth_rpc_eth_types::block::BlockAndReceipts;
 
 use xlayer_flashblocks::CachedTxInfo;
@@ -41,6 +41,19 @@ pub(crate) fn build_tx_info(
         block_number: Some(bar.block.number()),
         base_fee: bar.block.base_fee_per_gas(),
     }
+}
+
+/// Converts a `BlockAndReceipts` into an RPC header.
+pub(crate) fn to_rpc_header<Rpc>(
+    bar: &BlockAndReceipts<OpPrimitives>,
+    converter: &Rpc,
+) -> Result<RpcHeader<Optimism>, Rpc::Error>
+where
+    Rpc: RpcConvert<Network = Optimism, Primitives = OpPrimitives>,
+{
+    let sealed_header = bar.block.clone_sealed_header();
+    let block_size = bar.block.size();
+    converter.convert_header(sealed_header, block_size)
 }
 
 /// Converts a `BlockAndReceipts` into an RPC block.

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -256,22 +256,13 @@ async fn fb_pending_block_queries_test() {
 }
 
 /// Header-level RPC queries using the pending tag and by-hash lookups on the flashblocks node.
+/// Anchors on a concrete block first to avoid race conditions from pending advancing between calls.
 #[tokio::test]
 async fn fb_pending_header_queries_test() {
     let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
 
-    // eth_getHeaderByNumber(Pending) returns a header with essential fields
-    let pending_header =
-        operations::eth_get_header_by_number(&fb_client, operations::BlockId::Pending)
-            .await
-            .expect("eth_getHeaderByNumber(pending) failed");
-    assert!(!pending_header.is_null(), "Pending header should not be null");
-    assert!(pending_header["number"].is_string(), "Header should have a number field");
-    assert!(pending_header["hash"].is_string(), "Header should have a hash field");
-    assert!(pending_header["parentHash"].is_string(), "Header should have a parentHash field");
-    assert!(pending_header["stateRoot"].is_string(), "Header should have a stateRoot field");
-
-    // Pending header should match the block header from eth_getBlockByNumber
+    // Anchor on a concrete pending block to avoid race conditions — pending can advance
+    // every ~250ms, so we extract concrete identifiers from one call and use those throughout.
     let pending_block = operations::eth_get_block_by_number_or_hash(
         &fb_client,
         operations::BlockId::Pending,
@@ -279,34 +270,40 @@ async fn fb_pending_header_queries_test() {
     )
     .await
     .expect("eth_getBlockByNumber(pending) failed");
+    assert!(!pending_block.is_null(), "Pending block should not be null");
+
+    let block_hash = pending_block["hash"].as_str().expect("Block should have a hash");
+    let block_number = pending_block["number"]
+        .as_str()
+        .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+        .expect("Block should have a valid hex number");
+
+    // eth_getHeaderByNumber with the concrete block number
+    let header_by_number =
+        operations::eth_get_header_by_number(&fb_client, operations::BlockId::Number(block_number))
+            .await
+            .expect("eth_getHeaderByNumber failed");
+    assert!(!header_by_number.is_null(), "Header by number should not be null");
+    assert!(header_by_number["number"].is_string(), "Header should have a number field");
+    assert!(header_by_number["hash"].is_string(), "Header should have a hash field");
+    assert!(header_by_number["parentHash"].is_string(), "Header should have a parentHash field");
+    assert!(header_by_number["stateRoot"].is_string(), "Header should have a stateRoot field");
+
+    // Header fields should match the anchored block
     assert_eq!(
-        pending_header["hash"], pending_block["hash"],
+        header_by_number["hash"], pending_block["hash"],
         "Header hash should match block hash"
     );
     assert_eq!(
-        pending_header["number"], pending_block["number"],
+        header_by_number["number"], pending_block["number"],
         "Header number should match block number"
     );
     assert_eq!(
-        pending_header["stateRoot"], pending_block["stateRoot"],
+        header_by_number["stateRoot"], pending_block["stateRoot"],
         "Header stateRoot should match block stateRoot"
     );
 
-    // Pending header is also queryable by its actual block number
-    let header_number = pending_header["number"]
-        .as_str()
-        .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
-        .expect("Header number should be a valid hex string");
-    let header_by_number = operations::eth_get_header_by_number(
-        &fb_client,
-        operations::BlockId::Number(header_number),
-    )
-    .await
-    .expect("eth_getHeaderByNumber by actual number failed");
-    assert!(!header_by_number.is_null(), "Header by number should not be null");
-
     // eth_getHeaderByHash returns the same header
-    let block_hash = pending_header["hash"].as_str().expect("Header should have a hash");
     let header_by_hash = operations::eth_get_header_by_hash(&fb_client, block_hash)
         .await
         .expect("eth_getHeaderByHash failed");

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -256,28 +256,34 @@ async fn fb_pending_block_queries_test() {
 }
 
 /// Header-level RPC queries on the flashblocks node.
-/// Uses a confirmed block number (from `eth_blockNumber`) whose hash is stable, rather than
-/// the pending tag whose hash can change as the flashblock sequence advances.
 #[tokio::test]
 async fn fb_pending_header_queries_test() {
     let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
 
-    // Use the confirmed height — its hash is stable unlike pending
+    // eth_getHeaderByNumber(Pending) returns a non-null header with essential fields.
+    // Note: pending hash is ephemeral (changes as the sequence advances), so we only
+    // validate field presence here — no by-hash re-query against the pending hash.
+    let pending_header =
+        operations::eth_get_header_by_number(&fb_client, operations::BlockId::Pending)
+            .await
+            .expect("eth_getHeaderByNumber(pending) failed");
+    assert!(!pending_header.is_null(), "Pending header should not be null");
+    assert!(pending_header["number"].is_string(), "Header should have a number field");
+    assert!(pending_header["hash"].is_string(), "Header should have a hash field");
+    assert!(pending_header["parentHash"].is_string(), "Header should have a parentHash field");
+    assert!(pending_header["stateRoot"].is_string(), "Header should have a stateRoot field");
+
+    // Use confirmed height for by-number and by-hash assertions — its hash is stable
     let block_number =
         operations::eth_block_number(&fb_client).await.expect("Failed to get block number");
 
-    // eth_getHeaderByNumber returns a header with essential fields
     let header_by_number =
         operations::eth_get_header_by_number(&fb_client, operations::BlockId::Number(block_number))
             .await
-            .expect("eth_getHeaderByNumber failed");
-    assert!(!header_by_number.is_null(), "Header by number should not be null");
-    assert!(header_by_number["number"].is_string(), "Header should have a number field");
-    assert!(header_by_number["hash"].is_string(), "Header should have a hash field");
-    assert!(header_by_number["parentHash"].is_string(), "Header should have a parentHash field");
-    assert!(header_by_number["stateRoot"].is_string(), "Header should have a stateRoot field");
+            .expect("eth_getHeaderByNumber by confirmed number failed");
+    assert!(!header_by_number.is_null(), "Header by confirmed number should not be null");
 
-    // Header should match the block's header from eth_getBlockByNumber
+    // Header should match the block from eth_getBlockByNumber
     let block = operations::eth_get_block_by_number_or_hash(
         &fb_client,
         operations::BlockId::Number(block_number),
@@ -287,15 +293,11 @@ async fn fb_pending_header_queries_test() {
     .expect("eth_getBlockByNumber failed");
     assert_eq!(header_by_number["hash"], block["hash"], "Header hash should match block hash");
     assert_eq!(
-        header_by_number["number"], block["number"],
-        "Header number should match block number"
-    );
-    assert_eq!(
         header_by_number["stateRoot"], block["stateRoot"],
         "Header stateRoot should match block stateRoot"
     );
 
-    // eth_getHeaderByHash returns the same header
+    // eth_getHeaderByHash returns the same header (safe — confirmed hash is stable)
     let block_hash = header_by_number["hash"].as_str().expect("Header should have a hash");
     let header_by_hash = operations::eth_get_header_by_hash(&fb_client, block_hash)
         .await

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -255,6 +255,67 @@ async fn fb_pending_block_queries_test() {
     assert!(!raw_tx.is_null(), "Raw transaction at index 0 should not be null");
 }
 
+/// Header-level RPC queries using the pending tag and by-hash lookups on the flashblocks node.
+#[tokio::test]
+async fn fb_pending_header_queries_test() {
+    let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
+
+    // eth_getHeaderByNumber(Pending) returns a header with essential fields
+    let pending_header =
+        operations::eth_get_header_by_number(&fb_client, operations::BlockId::Pending)
+            .await
+            .expect("eth_getHeaderByNumber(pending) failed");
+    assert!(!pending_header.is_null(), "Pending header should not be null");
+    assert!(pending_header["number"].is_string(), "Header should have a number field");
+    assert!(pending_header["hash"].is_string(), "Header should have a hash field");
+    assert!(pending_header["parentHash"].is_string(), "Header should have a parentHash field");
+    assert!(pending_header["stateRoot"].is_string(), "Header should have a stateRoot field");
+
+    // Pending header should match the block header from eth_getBlockByNumber
+    let pending_block = operations::eth_get_block_by_number_or_hash(
+        &fb_client,
+        operations::BlockId::Pending,
+        false,
+    )
+    .await
+    .expect("eth_getBlockByNumber(pending) failed");
+    assert_eq!(
+        pending_header["hash"], pending_block["hash"],
+        "Header hash should match block hash"
+    );
+    assert_eq!(
+        pending_header["number"], pending_block["number"],
+        "Header number should match block number"
+    );
+    assert_eq!(
+        pending_header["stateRoot"], pending_block["stateRoot"],
+        "Header stateRoot should match block stateRoot"
+    );
+
+    // Pending header is also queryable by its actual block number
+    let header_number = pending_header["number"]
+        .as_str()
+        .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+        .expect("Header number should be a valid hex string");
+    let header_by_number = operations::eth_get_header_by_number(
+        &fb_client,
+        operations::BlockId::Number(header_number),
+    )
+    .await
+    .expect("eth_getHeaderByNumber by actual number failed");
+    assert!(!header_by_number.is_null(), "Header by number should not be null");
+
+    // eth_getHeaderByHash returns the same header
+    let block_hash = pending_header["hash"].as_str().expect("Header should have a hash");
+    let header_by_hash = operations::eth_get_header_by_hash(&fb_client, block_hash)
+        .await
+        .expect("eth_getHeaderByHash failed");
+    assert_eq!(
+        header_by_number, header_by_hash,
+        "eth_getHeaderByNumber and eth_getHeaderByHash should return identical headers"
+    );
+}
+
 /// Transaction-level RPC queries on the flashblocks node.
 #[tokio::test]
 async fn fb_pending_tx_queries_test() {
@@ -1242,6 +1303,48 @@ async fn fb_compare_get_block_by_hash() {
 
 #[ignore = "Requires a second non-flashblock RPC node to be running"]
 #[tokio::test]
+async fn fb_compare_get_header() {
+    let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
+    let non_fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_NO_FB);
+
+    let latest = operations::eth_block_number(&non_fb_client)
+        .await
+        .expect("Failed to get latest block number");
+
+    for i in 0..10 {
+        let block_id = operations::BlockId::Number(latest - i);
+
+        // By number
+        let fb_header = operations::eth_get_header_by_number(&fb_client, block_id.clone())
+            .await
+            .expect("Failed to get header from fb client");
+        let non_fb_header = operations::eth_get_header_by_number(&non_fb_client, block_id)
+            .await
+            .expect("Failed to get header from non-fb client");
+        assert_eq!(
+            fb_header,
+            non_fb_header,
+            "eth_getHeaderByNumber not identical at block {}",
+            latest - i
+        );
+
+        // By hash
+        let block_hash = fb_header["hash"].as_str().expect("Header should have hash");
+        let fb_header_by_hash = operations::eth_get_header_by_hash(&fb_client, block_hash)
+            .await
+            .expect("Failed to get header by hash from fb client");
+        let non_fb_header_by_hash = operations::eth_get_header_by_hash(&non_fb_client, block_hash)
+            .await
+            .expect("Failed to get header by hash from non-fb client");
+        assert_eq!(
+            fb_header_by_hash, non_fb_header_by_hash,
+            "eth_getHeaderByHash not identical for hash {block_hash}"
+        );
+    }
+}
+
+#[ignore = "Requires a second non-flashblock RPC node to be running"]
+#[tokio::test]
 async fn fb_compare_get_block_transaction_count() {
     let (fb_client, non_fb_client, _, block_num, fb_block_hash, non_fb_block_hash, _) =
         operations::comparison_test_setup().await;
@@ -1954,6 +2057,19 @@ async fn fb_negative_test() {
             .await
             .expect("eth_getRawTransactionByBlockNumberAndIndex should not error for bad index");
     assert!(result.is_null(), "Out-of-range tx index should return null, got: {result}");
+
+    // Non-existent header by number returns null
+    let header =
+        operations::eth_get_header_by_number(&fb_client, operations::BlockId::Number(0xFFFFFFFF))
+            .await
+            .expect("eth_getHeaderByNumber should not error for non-existent block");
+    assert!(header.is_null(), "Non-existent block header should return null, got: {header}");
+
+    // Non-existent header by hash returns null
+    let header = operations::eth_get_header_by_hash(&fb_client, fake_hash)
+        .await
+        .expect("eth_getHeaderByHash should not error for non-existent hash");
+    assert!(header.is_null(), "Non-existent hash header should return null, got: {header}");
 }
 
 /// Verifies that `eth_getLogs` returns logs from a flashblock when queried

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -255,30 +255,18 @@ async fn fb_pending_block_queries_test() {
     assert!(!raw_tx.is_null(), "Raw transaction at index 0 should not be null");
 }
 
-/// Header-level RPC queries using the pending tag and by-hash lookups on the flashblocks node.
-/// Anchors on a concrete block first to avoid race conditions from pending advancing between calls.
+/// Header-level RPC queries on the flashblocks node.
+/// Uses a confirmed block number (from `eth_blockNumber`) whose hash is stable, rather than
+/// the pending tag whose hash can change as the flashblock sequence advances.
 #[tokio::test]
 async fn fb_pending_header_queries_test() {
     let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
 
-    // Anchor on a concrete pending block to avoid race conditions — pending can advance
-    // every ~250ms, so we extract concrete identifiers from one call and use those throughout.
-    let pending_block = operations::eth_get_block_by_number_or_hash(
-        &fb_client,
-        operations::BlockId::Pending,
-        false,
-    )
-    .await
-    .expect("eth_getBlockByNumber(pending) failed");
-    assert!(!pending_block.is_null(), "Pending block should not be null");
+    // Use the confirmed height — its hash is stable unlike pending
+    let block_number =
+        operations::eth_block_number(&fb_client).await.expect("Failed to get block number");
 
-    let block_hash = pending_block["hash"].as_str().expect("Block should have a hash");
-    let block_number = pending_block["number"]
-        .as_str()
-        .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
-        .expect("Block should have a valid hex number");
-
-    // eth_getHeaderByNumber with the concrete block number
+    // eth_getHeaderByNumber returns a header with essential fields
     let header_by_number =
         operations::eth_get_header_by_number(&fb_client, operations::BlockId::Number(block_number))
             .await
@@ -289,21 +277,26 @@ async fn fb_pending_header_queries_test() {
     assert!(header_by_number["parentHash"].is_string(), "Header should have a parentHash field");
     assert!(header_by_number["stateRoot"].is_string(), "Header should have a stateRoot field");
 
-    // Header fields should match the anchored block
+    // Header should match the block's header from eth_getBlockByNumber
+    let block = operations::eth_get_block_by_number_or_hash(
+        &fb_client,
+        operations::BlockId::Number(block_number),
+        false,
+    )
+    .await
+    .expect("eth_getBlockByNumber failed");
+    assert_eq!(header_by_number["hash"], block["hash"], "Header hash should match block hash");
     assert_eq!(
-        header_by_number["hash"], pending_block["hash"],
-        "Header hash should match block hash"
-    );
-    assert_eq!(
-        header_by_number["number"], pending_block["number"],
+        header_by_number["number"], block["number"],
         "Header number should match block number"
     );
     assert_eq!(
-        header_by_number["stateRoot"], pending_block["stateRoot"],
+        header_by_number["stateRoot"], block["stateRoot"],
         "Header stateRoot should match block stateRoot"
     );
 
     // eth_getHeaderByHash returns the same header
+    let block_hash = header_by_number["hash"].as_str().expect("Header should have a hash");
     let header_by_hash = operations::eth_get_header_by_hash(&fb_client, block_hash)
         .await
         .expect("eth_getHeaderByHash failed");

--- a/crates/tests/operations/eth_rpc.rs
+++ b/crates/tests/operations/eth_rpc.rs
@@ -437,3 +437,24 @@ pub async fn eth_send_raw_transaction_sync(client_rpc: &HttpClient, raw_tx: &str
     .await??;
     Ok(result)
 }
+
+/// For eth_getHeaderByNumber
+pub async fn eth_get_header_by_number(client_rpc: &HttpClient, block_id: BlockId) -> Result<Value> {
+    let block_id = block_id.to_rpc_param();
+    let result: Value = tokio::time::timeout(
+        RPC_TIMEOUT,
+        client_rpc.request("eth_getHeaderByNumber", jsonrpsee::rpc_params![block_id]),
+    )
+    .await??;
+    Ok(result)
+}
+
+/// For eth_getHeaderByHash
+pub async fn eth_get_header_by_hash(client_rpc: &HttpClient, block_hash: &str) -> Result<Value> {
+    let result: Value = tokio::time::timeout(
+        RPC_TIMEOUT,
+        client_rpc.request("eth_getHeaderByHash", jsonrpsee::rpc_params![block_hash]),
+    )
+    .await??;
+    Ok(result)
+}


### PR DESCRIPTION
## Summary

- Add flashblocks eth API support for `eth_getHeaderByNumber` and `eth_getHeaderByHash`