### PR TITLE
fix(builder): stop rb_test macro from overriding user-supplied flashblocks_end_buffer_ms

### DIFF
--- a/crates/builder/src/tests/framework/macros/src/lib.rs
+++ b/crates/builder/src/tests/framework/macros/src/lib.rs
@@ -80,7 +80,6 @@ fn generate_instance_init(
                     let mut args = #args_expr;
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = crate::tests::get_available_port();
-                    args.flashblocks.flashblocks_end_buffer_ms = 75;
                     args
                 }).await?
             }
@@ -91,7 +90,6 @@ fn generate_instance_init(
                     let mut args = crate::args::BuilderArgs::default();
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = crate::tests::get_available_port();
-                    args.flashblocks.flashblocks_end_buffer_ms = 75;
                     args
                 }, #config_expr).await?
             }
@@ -102,7 +100,6 @@ fn generate_instance_init(
                     let mut args = #args_expr;
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = crate::tests::get_available_port();
-                    args.flashblocks.flashblocks_end_buffer_ms = 75;
                     args
                 }, #config_expr).await?
             }

--- a/crates/builder/src/tests/framework/macros/src/lib.rs
+++ b/crates/builder/src/tests/framework/macros/src/lib.rs
@@ -80,6 +80,9 @@ fn generate_instance_init(
                     let mut args = #args_expr;
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = crate::tests::get_available_port();
+                    if args.flashblocks.flashblocks_end_buffer_ms == 0 {
+                        args.flashblocks.flashblocks_end_buffer_ms = 75;
+                    }
                     args
                 }).await?
             }
@@ -90,6 +93,9 @@ fn generate_instance_init(
                     let mut args = crate::args::BuilderArgs::default();
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = crate::tests::get_available_port();
+                    if args.flashblocks.flashblocks_end_buffer_ms == 0 {
+                        args.flashblocks.flashblocks_end_buffer_ms = 75;
+                    }
                     args
                 }, #config_expr).await?
             }
@@ -100,6 +106,9 @@ fn generate_instance_init(
                     let mut args = #args_expr;
                     args.flashblocks.enabled = true;
                     args.flashblocks.flashblocks_port = crate::tests::get_available_port();
+                    if args.flashblocks.flashblocks_end_buffer_ms == 0 {
+                        args.flashblocks.flashblocks_end_buffer_ms = 75;
+                    }
                     args
                 }, #config_expr).await?
             }


### PR DESCRIPTION
## Summary

The `rb_test` proc macro silently overrode the `flashblocks_end_buffer_ms` value that test authors pass via `args = BuilderArgs { ... }`, hard-coding it to `75` regardless of user intent.

Several existing tests (e.g. `flashblocks.rs`, `smoke.rs`, `data_availability.rs`, `miner_gas_limit.rs`, `forks.rs`) explicitly set `flashblocks_end_buffer_ms: 50` in their `FlashblocksArgs`, expecting 50 to be used — but the macro replaced it with 75 at expansion time. This made the field effectively un-configurable per test and made the written value misleading.

Unlike the `enabled = true` and `flashblocks_port = get_available_port()` overrides (which enforce test invariants: flashblocks must be on, ports must not collide under parallel execution), there is no test-level invariant that requires `end_buffer_ms = 75`. It was a latent override that silently contradicted the user's input.

## Changes

Replaced the unconditional override:

```rust
args.flashblocks.flashblocks_end_buffer_ms = 75;
with a guard that only applies the default when the user did not specify a value (i.e. it is still the clap default of 0):


if args.flashblocks.flashblocks_end_buffer_ms == 0 {
    args.flashblocks.flashblocks_end_buffer_ms = 75;
}
```