### PR TITLE
fix: Fix eth_getLogs pending state handling, and more e2e pending state coverage

### DIFF
--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -255,7 +255,6 @@ fn main() {
 
                         // Register flashblocks filter override (eth_getLogs)
                         let flashblocks_filter = FlashblocksEthFilterExt::new(
-                            ctx.registry.eth_api().clone(),
                             ctx.registry.eth_handlers().filter.clone(),
                             flashblocks_state.clone(),
                             ctx.config().rpc.eth_config().filter_config(),

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -39,7 +39,6 @@ pub trait FlashblocksFilterOverride {
 /// Extended filter API with flashblocks cache overlay.
 #[derive(Debug)]
 pub struct FlashblocksEthFilterExt<Eth: EthApiTypes> {
-    eth_api: Eth,
     eth_filter: EthFilter<Eth>,
     flashblocks_state: FlashblockStateCache<OpPrimitives>,
     query_limits: QueryLimits,
@@ -49,7 +48,6 @@ pub struct FlashblocksEthFilterExt<Eth: EthApiTypes> {
 impl<Eth: EthApiTypes + RpcNodeCore> FlashblocksEthFilterExt<Eth> {
     /// Creates a new [`FlashblocksEthFilterExt`].
     pub fn new(
-        eth_api: Eth,
         eth_filter: EthFilter<Eth>,
         flashblocks_state: FlashblockStateCache<OpPrimitives>,
         config: EthFilterConfig,
@@ -57,7 +55,6 @@ impl<Eth: EthApiTypes + RpcNodeCore> FlashblocksEthFilterExt<Eth> {
         let EthFilterConfig { max_blocks_per_filter, max_logs_per_response, stale_filter_ttl } =
             config;
         Self {
-            eth_api,
             eth_filter,
             flashblocks_state,
             _stale_filter_ttl: stale_filter_ttl,
@@ -112,48 +109,47 @@ where
                     return self.eth_filter.logs(filter).await;
                 }
 
-                let from = from_block
-                    .map(|num| {
-                        if let Some(bar) = self.flashblocks_state.get_rpc_block(num) {
-                            Ok(Some(bar.block.number()))
-                        } else {
-                            self.eth_api.provider().convert_block_number(num).to_rpc_result()
-                        }
-                    })
-                    .transpose()?
-                    .flatten();
-                let to = match to_block {
-                    Some(num) => {
-                        let Some(bar) = self.flashblocks_state.get_rpc_block(num) else {
-                            // to block is not in the flashblock cache, delegate to canonical filter
-                            return EthFilterApiServer::logs(&self.eth_filter, filter).await;
-                        };
-                        Some(bar.block.number())
-                    }
+                let pending_height = self.flashblocks_state.get_pending_height();
+                let confirm_height = self.flashblocks_state.get_confirm_height();
+                if confirm_height == 0 || pending_height == 0 {
+                    // Cache not initialized, delegate to canonical filter
+                    return self.eth_filter.logs(filter).await;
+                }
+
+                let from = match from_block {
+                    Some(tag) => match resolve_fb_bound(tag, confirm_height, pending_height) {
+                        Some(n) => Some(n),
+                        None => return self.eth_filter.logs(filter).await,
+                    },
                     None => None,
                 };
-                let start_block = self.flashblocks_state.get_confirm_height();
-                let end_block = self.flashblocks_state.get_pending_height();
-                if end_block == 0 || start_block == 0 {
-                    return EthFilterApiServer::logs(&self.eth_filter, filter).await;
-                }
+                let to = match to_block {
+                    Some(tag) => match resolve_fb_bound(tag, confirm_height, pending_height) {
+                        Some(n) => Some(n),
+                        None => return self.eth_filter.logs(filter).await,
+                    },
+                    None => None,
+                };
+
+                let default_start_block = confirm_height;
+                let default_end_block = pending_height;
 
                 // Return error if fromBlock exceeds current tip
                 if let Some(f) = from
-                    && f > end_block
+                    && f > pending_height
                 {
                     return Err(EthFilterError::BlockRangeExceedsHead.into());
                 }
                 // Return error if fromBlock exceeds current head
                 if let Some(f) = from
-                    && f > start_block
+                    && f > confirm_height
                 {
                     // start block higher than local head, can return empty
                     return Ok(Vec::new());
                 }
 
                 let (from_block_number, to_block_number) =
-                    get_filter_block_range(from, to, start_block, end_block)
+                    get_filter_block_range(from, to, default_start_block, default_end_block)
                         .map_err(EthFilterError::from)?;
 
                 // Query filter limit check
@@ -165,7 +161,8 @@ where
                     return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter).into());
                 }
 
-                // Get block logs from flashblocks state
+                // Get block logs from flashblocks state. Note that we cannot assume that flashblocks
+                // state has not advanced since the last retrieval of pending and confirmed heights.
                 let mut fb_logs: Vec<Vec<Log>> = Vec::new();
                 let mut canonical_end = None;
                 for num in (from_block_number..=to_block_number).rev() {
@@ -238,22 +235,20 @@ where
 fn get_filter_block_range(
     from_block: Option<u64>,
     to_block: Option<u64>,
-    start_block: u64,
-    end_block: u64,
+    default_start_block: u64,
+    default_end_block: u64,
 ) -> Result<(u64, u64), FilterBlockRangeError> {
-    let from_block_number = from_block.unwrap_or(start_block);
-    let to_block_number = to_block.unwrap_or(end_block);
+    let from_block_number = from_block.unwrap_or(default_start_block);
+    let to_block_number = to_block.unwrap_or(default_end_block);
 
     // from > to is an invalid range
     if from_block_number > to_block_number {
         return Err(FilterBlockRangeError::InvalidBlockRange);
     }
-
     // we cannot query blocks that don't exist yet
-    if to_block_number > end_block {
+    if to_block_number > default_end_block {
         return Err(FilterBlockRangeError::BlockRangeExceedsHead);
     }
-
     Ok((from_block_number, to_block_number))
 }
 
@@ -269,4 +264,19 @@ fn get_matching_logs_from_bar(bar: &BlockAndReceipts<OpPrimitives>, filter: &Fil
         tx_hashes_and_receipts,
         false,
     )
+}
+
+/// Resolves a [`BlockNumberOrTag`] to an absolute block number using the flashblocks
+/// cache heights.
+fn resolve_fb_bound(
+    tag: BlockNumberOrTag,
+    confirm_height: u64,
+    pending_height: u64,
+) -> Option<u64> {
+    match tag {
+        BlockNumberOrTag::Pending => Some(pending_height),
+        BlockNumberOrTag::Latest => Some(confirm_height),
+        BlockNumberOrTag::Number(n) => Some(n),
+        BlockNumberOrTag::Earliest | BlockNumberOrTag::Safe | BlockNumberOrTag::Finalized => None,
+    }
 }

--- a/crates/rpc/src/filter.rs
+++ b/crates/rpc/src/filter.rs
@@ -134,18 +134,16 @@ where
                 let default_start_block = confirm_height;
                 let default_end_block = pending_height;
 
-                // Return error if fromBlock exceeds current tip
+                // Return error if range exceeds current tip (pending)
+                if let Some(t) = to
+                    && t > pending_height
+                {
+                    return Err(EthFilterError::BlockRangeExceedsHead.into());
+                }
                 if let Some(f) = from
                     && f > pending_height
                 {
                     return Err(EthFilterError::BlockRangeExceedsHead.into());
-                }
-                // Return error if fromBlock exceeds current head
-                if let Some(f) = from
-                    && f > confirm_height
-                {
-                    // start block higher than local head, can return empty
-                    return Ok(Vec::new());
                 }
 
                 let (from_block_number, to_block_number) =

--- a/crates/tests/flashblocks-tests/main.rs
+++ b/crates/tests/flashblocks-tests/main.rs
@@ -23,6 +23,40 @@ use xlayer_e2e_test::operations;
 const ITERATIONS: usize = 11;
 const TX_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(10);
 const WEB_SOCKET_TIMEOUT: Duration = Duration::from_secs(30);
+/// Approximate L2 block time used to wait for the next block to mint before a test
+/// starts sending transactions, avoiding block-boundary races during pending-state reads.
+const BLOCK_TIME: Duration = Duration::from_secs(1);
+
+/// Sleeps for approximately one L2 block time so the next block has a chance to mint
+/// before the test sends any transactions.
+async fn sleep_one_blocktime() {
+    tokio::time::sleep(BLOCK_TIME).await;
+}
+
+/// Reads an ERC20 token balance for `account` on the flashblocks `Pending` tag
+/// by calling `balanceOf(account)` via `eth_call`. Builds calldata manually to
+/// avoid `sol!` macro name collisions with per-test `balanceOf` definitions.
+async fn erc20_balance_of_pending(
+    client: &operations::HttpClient,
+    erc20: Address,
+    account: &str,
+) -> U256 {
+    // ERC20 balanceOf(address) selector = 0x70a08231
+    let addr = Address::from_str(account).expect("Invalid address");
+    let mut calldata = Vec::with_capacity(36);
+    calldata.extend_from_slice(&[0x70, 0xa0, 0x82, 0x31]);
+    calldata.extend_from_slice(&[0u8; 12]);
+    calldata.extend_from_slice(addr.as_slice());
+    let args = json!({
+        "to": erc20,
+        "data": format!("0x{}", hex::encode(&calldata)),
+    });
+    let result = operations::eth_call(client, Some(args), Some(operations::BlockId::Pending))
+        .await
+        .expect("eth_call balanceOf(pending) failed");
+    U256::from_str_radix(result.trim_start_matches("0x"), 16)
+        .expect("Failed to parse balanceOf result")
+}
 
 // ========================================================================
 // Flashblocks enabled/disabled tests
@@ -177,6 +211,7 @@ async fn fb_low_latency_pending_visibility_test() {
 /// Block-level RPC queries using the pending tag on the flashblocks node.
 #[tokio::test]
 async fn fb_pending_block_queries_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -311,6 +346,7 @@ async fn fb_pending_header_queries_test() {
 /// Transaction-level RPC queries on the flashblocks node.
 #[tokio::test]
 async fn fb_pending_tx_queries_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -354,6 +390,7 @@ async fn fb_pending_tx_queries_test() {
 /// State-reading RPC queries using the pending tag on the flashblocks node.
 #[tokio::test]
 async fn fb_pending_state_queries_test() {
+    sleep_one_blocktime().await;
     let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
     let sender_address = operations::DEFAULT_RICH_ADDRESS;
     let test_address = operations::DEFAULT_L2_NEW_ACC1_ADDRESS;
@@ -436,6 +473,7 @@ async fn fb_pending_state_queries_test() {
 /// results in non-empty bytecode at the deployed address when queried with the pending tag.
 #[tokio::test]
 async fn fb_pending_create2_deploy_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -489,6 +527,7 @@ async fn fb_pending_create2_deploy_test() {
 /// Verifies that the CREATE2 `computeAddress` result matches the actual deployed address.
 #[tokio::test]
 async fn fb_pending_create2_address_determinism_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -563,6 +602,7 @@ async fn fb_pending_create2_address_determinism_test() {
 /// separate transaction (EIP-6780 behavior).
 #[tokio::test]
 async fn fb_pending_selfdestruct_code_persists_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -672,6 +712,7 @@ async fn fb_pending_precompile_call_test() {
 /// balance correctly through the flashblocks pending state.
 #[tokio::test]
 async fn fb_pending_transfer_to_precompile_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -717,9 +758,12 @@ async fn fb_pending_transfer_to_precompile_test() {
 }
 
 /// Verifies that `eth_getLogs` returns Transfer event logs from an ERC20 token
-/// transfer when queried with the transaction's block range.
+/// transfer immediately after confirmation, served from the flashblocks confirm
+/// cache ahead of the canonical chain. The test queries using the `Pending` tag
+/// to exercise the flashblocks state cache overlay.
 #[tokio::test]
 async fn fb_pending_get_logs_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -727,6 +771,11 @@ async fn fb_pending_get_logs_test() {
     let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
     let contracts = operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
     let test_address = operations::DEFAULT_L2_NEW_ACC1_ADDRESS;
+
+    // Snapshot the canonical tip so we can prove the query range spans blocks
+    // that are ahead of canonical (i.e., served from the flashblocks cache).
+    let canonical_before =
+        operations::eth_block_number(&fb_client).await.expect("Failed to read canonical height");
 
     // Send an ERC20 transfer
     let tx_hash = operations::erc20_balance_transfer(
@@ -744,38 +793,35 @@ async fn fb_pending_get_logs_test() {
         .await
         .expect("ERC20 transfer tx not mined");
 
-    // Use the exact block from the receipt for a tight query range
     let tx_block = receipt["blockNumber"]
         .as_str()
         .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
         .expect("Failed to parse block number from receipt");
+    assert!(
+        tx_block > canonical_before,
+        "Expected tx_block ({tx_block}) to be ahead of the canonical tip observed before send ({canonical_before}) so the log is served from the flashblocks cache"
+    );
 
-    // Wait for canonical chain to reach the tx block so eth_getLogs can serve it
-    operations::wait_for_canonical_block(operations::DEFAULT_L2_NETWORK_URL_FB, tx_block)
-        .await
-        .expect("Canonical chain did not reach tx block");
-
-    // Query logs from the ERC20 contract address
-    // Transfer event topic: keccak256("Transfer(address,address,uint256)")
+    // Query logs across the confirm cache up to pending — this must hit the
+    // flashblocks state cache, not the canonical chain.
     let transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
     let logs = operations::eth_get_logs(
         &fb_client,
         Some(operations::BlockId::Number(tx_block)),
-        Some(operations::BlockId::Number(tx_block)),
+        Some(operations::BlockId::Pending),
         Some(&format!("{:#x}", contracts.erc20)),
         Some(vec![transfer_topic.to_string()]),
     )
     .await
-    .expect("eth_getLogs failed");
+    .expect("eth_getLogs(pending) failed");
 
     let logs_arr = logs.as_array().expect("Logs should be an array");
-    assert!(!logs_arr.is_empty(), "Should have at least one Transfer log");
+    assert!(!logs_arr.is_empty(), "Should have at least one Transfer log on pending");
 
-    // Find the log from our specific transaction
     let our_log = logs_arr
         .iter()
         .find(|log| log["transactionHash"].as_str() == Some(tx_hash.as_str()))
-        .expect("Should find a Transfer log from our transaction");
+        .expect("Should find a Transfer log from our transaction on pending");
 
     assert_eq!(
         our_log["address"].as_str().unwrap().to_lowercase(),
@@ -788,6 +834,7 @@ async fn fb_pending_get_logs_test() {
 /// `triggerCall`) works correctly through the flashblocks node.
 #[tokio::test]
 async fn fb_pending_contract_to_contract_call_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -849,6 +896,7 @@ async fn fb_pending_contract_to_contract_call_test() {
 /// after a transfer.
 #[tokio::test]
 async fn fb_pending_state_transition_across_blocks_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -913,6 +961,157 @@ async fn fb_pending_state_transition_across_blocks_test() {
     assert_eq!(
         balance_at_n, balance_at_n_again,
         "Historical balance at block {block_n} should be immutable"
+    );
+}
+
+/// Verifies that immediately after a native ETH transfer, the pending state
+/// reflects the exact balance deltas on both sender and recipient, and the
+/// sender's pending nonce has incremented by 1.
+#[tokio::test]
+async fn fb_pending_native_balance_delta_test() {
+    sleep_one_blocktime().await;
+    operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
+        .await
+        .expect("Failed to settle pending transactions");
+
+    let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
+    let sender_address = operations::DEFAULT_RICH_ADDRESS;
+    let recipient_address = operations::DEFAULT_L2_NEW_ACC1_ADDRESS;
+    let transfer_amount = U256::from(operations::GWEI);
+
+    // Snapshot pending state before the transfer
+    let sender_balance_before =
+        operations::get_balance(&fb_client, sender_address, Some(operations::BlockId::Pending))
+            .await
+            .expect("Failed to read sender balance on pending");
+    let recipient_balance_before =
+        operations::get_balance(&fb_client, recipient_address, Some(operations::BlockId::Pending))
+            .await
+            .expect("Failed to read recipient balance on pending");
+    let sender_nonce_before = operations::eth_get_transaction_count(
+        &fb_client,
+        sender_address,
+        Some(operations::BlockId::Pending),
+    )
+    .await
+    .expect("Failed to read sender nonce on pending");
+
+    // Send the native transfer and wait for confirmation so the receipt is available
+    let tx_hash = operations::native_balance_transfer(
+        operations::DEFAULT_L2_NETWORK_URL_FB,
+        transfer_amount,
+        recipient_address,
+        None,
+        true,
+    )
+    .await
+    .expect("Native transfer failed");
+
+    // Extract gasUsed and effectiveGasPrice from the receipt to compute the sender's cost
+    let receipt = operations::eth_get_transaction_receipt(&fb_client, &tx_hash)
+        .await
+        .expect("Failed to fetch receipt");
+    let gas_used = U256::from_str_radix(
+        receipt["gasUsed"].as_str().expect("Receipt missing gasUsed").trim_start_matches("0x"),
+        16,
+    )
+    .expect("Failed to parse gasUsed");
+    let effective_gas_price = U256::from_str_radix(
+        receipt["effectiveGasPrice"]
+            .as_str()
+            .expect("Receipt missing effectiveGasPrice")
+            .trim_start_matches("0x"),
+        16,
+    )
+    .expect("Failed to parse effectiveGasPrice");
+    let gas_cost = gas_used * effective_gas_price;
+
+    // Read pending state again immediately after the transfer confirms
+    let sender_balance_after =
+        operations::get_balance(&fb_client, sender_address, Some(operations::BlockId::Pending))
+            .await
+            .expect("Failed to read sender balance on pending after");
+    let recipient_balance_after =
+        operations::get_balance(&fb_client, recipient_address, Some(operations::BlockId::Pending))
+            .await
+            .expect("Failed to read recipient balance on pending after");
+    let sender_nonce_after = operations::eth_get_transaction_count(
+        &fb_client,
+        sender_address,
+        Some(operations::BlockId::Pending),
+    )
+    .await
+    .expect("Failed to read sender nonce on pending after");
+
+    assert_eq!(
+        recipient_balance_after,
+        recipient_balance_before + transfer_amount,
+        "Recipient pending balance should increase by exactly the transfer amount"
+    );
+    assert_eq!(
+        sender_balance_after,
+        sender_balance_before - transfer_amount - gas_cost,
+        "Sender pending balance should decrease by transfer amount + gas cost"
+    );
+    assert_eq!(
+        sender_nonce_after,
+        sender_nonce_before + 1,
+        "Sender pending nonce should increment by 1"
+    );
+}
+
+/// Verifies that immediately after an ERC20 transfer, the pending state reflects
+/// the exact token balance deltas on both sender and recipient when queried via
+/// `eth_call(balanceOf, Pending)`.
+#[tokio::test]
+async fn fb_pending_erc20_balance_delta_test() {
+    sleep_one_blocktime().await;
+    operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
+        .await
+        .expect("Failed to settle pending transactions");
+
+    let fb_client = operations::create_test_client(operations::DEFAULT_L2_NETWORK_URL_FB);
+    let contracts = operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
+    let sender_address = operations::DEFAULT_RICH_ADDRESS;
+    let recipient_address = operations::DEFAULT_L2_NEW_ACC1_ADDRESS;
+    let transfer_amount = U256::from(operations::GWEI);
+
+    // Snapshot ERC20 balances on pending before the transfer
+    let sender_erc20_before =
+        erc20_balance_of_pending(&fb_client, contracts.erc20, sender_address).await;
+    let recipient_erc20_before =
+        erc20_balance_of_pending(&fb_client, contracts.erc20, recipient_address).await;
+
+    // Send the ERC20 transfer and wait for it to be mined
+    let tx_hash = operations::erc20_balance_transfer(
+        operations::DEFAULT_L2_NETWORK_URL_FB,
+        transfer_amount,
+        None,
+        recipient_address,
+        contracts.erc20,
+        None,
+    )
+    .await
+    .expect("ERC20 transfer failed");
+    operations::wait_for_tx_mined(operations::DEFAULT_L2_NETWORK_URL_FB, &tx_hash)
+        .await
+        .expect("ERC20 transfer tx not mined");
+
+    // Re-read ERC20 balances on pending immediately
+    let sender_erc20_after =
+        erc20_balance_of_pending(&fb_client, contracts.erc20, sender_address).await;
+    let recipient_erc20_after =
+        erc20_balance_of_pending(&fb_client, contracts.erc20, recipient_address).await;
+
+    assert_eq!(
+        recipient_erc20_after,
+        recipient_erc20_before + transfer_amount,
+        "Recipient pending ERC20 balance should increase by exactly the transfer amount"
+    );
+    assert_eq!(
+        sender_erc20_after,
+        sender_erc20_before - transfer_amount,
+        "Sender pending ERC20 balance should decrease by exactly the transfer amount"
     );
 }
 
@@ -1957,6 +2156,7 @@ async fn fb_compare_get_storage_at() {
 /// Verifies `eth_sendRawTransactionSync` returns inclusion data synchronously.
 #[tokio::test]
 async fn fb_send_raw_transaction_sync_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -2210,6 +2410,7 @@ async fn fb_get_logs_by_block_hash_test() {
 /// flashblock-cached blocks returns logs in ascending order.
 #[tokio::test]
 async fn fb_get_logs_cross_boundary_range_test() {
+    sleep_one_blocktime().await;
     operations::settle_pending_transactions(operations::DEFAULT_L2_NETWORK_URL_FB)
         .await
         .expect("Failed to settle pending transactions");
@@ -2218,8 +2419,9 @@ async fn fb_get_logs_cross_boundary_range_test() {
     let contracts = operations::try_deploy_contracts().await.expect("Failed to deploy contracts");
     let test_address = operations::DEFAULT_L2_NEW_ACC1_ADDRESS;
 
-    // Get the current canonical height
-    let canonical_height =
+    // Snapshot canonical tip before sending — this is the fromBlock anchor for
+    // the range query and the reference used to prove the tx lands ahead of canonical.
+    let canonical_before =
         operations::eth_block_number(&fb_client).await.expect("Failed to get block number");
 
     // Send a transfer so a flashblock ahead of canonical has a log
@@ -2242,15 +2444,15 @@ async fn fb_get_logs_cross_boundary_range_test() {
         .as_str()
         .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
         .expect("Failed to parse block number from receipt");
+    assert!(
+        tx_block_number > canonical_before,
+        "Expected tx_block_number ({tx_block_number}) to be ahead of canonical_before ({canonical_before}) so the range genuinely crosses the canonical → flashblock boundary"
+    );
 
-    // Wait for canonical chain to reach the tx block so eth_getLogs can serve it
-    operations::wait_for_canonical_block(operations::DEFAULT_L2_NETWORK_URL_FB, tx_block_number)
-        .await
-        .expect("Canonical chain did not reach tx block");
-
-    // Query a range that starts a few blocks before canonical height and goes
-    // to latest, ensuring we cross the canonical → flashblock boundary.
-    let from_block = canonical_height.saturating_sub(2);
+    // Query a range from a few blocks before the pre-send canonical tip up to
+    // Pending — this must span canonical blocks and flashblock cache blocks,
+    // exercising the cross-boundary log serving path.
+    let from_block = canonical_before.saturating_sub(2);
     let transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
     let logs = operations::eth_get_logs(
         &fb_client,

--- a/crates/tests/operations/utils.rs
+++ b/crates/tests/operations/utils.rs
@@ -537,7 +537,7 @@ pub async fn wait_for_tx_mined(endpoint_url: &str, tx_hash: &str) -> Result<serd
                     return Err(eyre!("tx execution failed with status: {}", status));
                 }
             }
-            tokio::time::sleep(Duration::from_millis(500)).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     })
     .await


### PR DESCRIPTION
## Description

Two related changes to the flashblocks RPC layer.

**Fix `eth_getLogs` pending-state handling** (`crates/rpc/src/filter.rs`)

`toBlock=Pending`/`Latest` delegated the whole filter to the canonical filter whenever `get_rpc_block` returned `None` — which happens in the brief window after a pending sequence is promoted (`pending_cache = None`) or after canonical catch-up evicts the confirm-cache entry. The canonical filter then resolves `Pending`/`Latest` against canonical and drops logs from confirm-cache blocks ahead of canonical.

Now resolves `Pending`/`Latest` directly to `pending_height`/`confirm_height` from the flashblocks state cache; the existing range scan handles cross-boundary fallback via `get_canonical_logs`. `Earliest`/`Safe`/`Finalized` delegate the whole filter to canonical (they are not served by the FB cache), distinguished from "no bound supplied" so the bound is not silently collapsed into the FB cache range.

**More e2e pending-state coverage** (`crates/tests/flashblocks-tests/main.rs`)

- `fb_pending_native_balance_delta_test` — asserts sender/recipient balance deltas and sender nonce increment on `Pending` immediately after a native transfer.
- `fb_pending_erc20_balance_delta_test` — asserts sender/recipient ERC20 balance deltas on `Pending` via `eth_call(balanceOf)` immediately after an ERC20 transfer.
- `sleep_one_blocktime()` (~1 block) at the start of pending-state tests that send transactions to avoid block-boundary races.
- Reworked `fb_pending_get_logs_test` and `fb_get_logs_cross_boundary_range_test` to query via `Pending` / `Number(tx_block)` ahead-of-canonical ranges instead of waiting for canonical catch-up — exercising the actual flashblocks overlay.

## Type of Change

- [x] Bug fix
- [x] Refactoring (no functional changes) — simplified `FlashblocksEthFilterExt::logs` flow

## Testing

- `cargo check -p xlayer-rpc`, `cargo clippy -p xlayer-rpc --all-targets -- -D warnings`, `cargo fmt -p xlayer-rpc -- --check`
- `cargo check/clippy/fmt -p xlayer-e2e-test --test flashblocks_tests`
- E2E: `fb_pending_get_logs_test` reliably passes against a running devnet, including in the `pending_cache = None` window that previously caused intermittent failures.

## Additional Notes

None — no public API changes outside `FlashblocksEthFilterExt::new` dropping the unused `eth_api` parameter (`bin/node/src/main.rs` updated in the same commit).