### PR TITLE
feat(flashblocks rpc): add validation duration and SR strategy logging in sequence validator

### DIFF
--- a/crates/flashblocks/src/execution/validator.rs
+++ b/crates/flashblocks/src/execution/validator.rs
@@ -492,6 +492,8 @@ where
         )?;
 
         let elapsed = validation_start.elapsed();
+        // `strategy` is a placeholder when SR is skipped; only surface it when SR actually ran.
+        let logged_strategy = calculate_state_root.then_some(strategy);
         info!(
             target: "flashblocks",
             execution_height,
@@ -499,7 +501,7 @@ where
             target_index,
             ?block_hash,
             full_sequence = calculate_state_root,
-            state_root_strategy = ?strategy,
+            state_root_strategy = ?logged_strategy,
             ?elapsed,
             "Executed and validated flashblocks sequence",
         );

--- a/crates/flashblocks/src/execution/validator.rs
+++ b/crates/flashblocks/src/execution/validator.rs
@@ -145,6 +145,8 @@ where
         N::SignedTx: Encodable2718,
         N::Block: From<alloy_consensus::Block<N::SignedTx>>,
     {
+        let validation_start = Instant::now();
+
         // Pre-validate incoming flashblocks sequence
         let pending_sequence = self.prevalidate_incoming_sequence(&args)?;
 
@@ -489,12 +491,16 @@ where
             calculate_state_root,
         )?;
 
+        let elapsed = validation_start.elapsed();
         info!(
             target: "flashblocks",
             execution_height,
             last_index,
             target_index,
             ?block_hash,
+            full_sequence = calculate_state_root,
+            state_root_strategy = ?strategy,
+            ?elapsed,
             "Executed and validated flashblocks sequence",
         );
         Ok(())

--- a/crates/flashblocks/src/execution/validator.rs
+++ b/crates/flashblocks/src/execution/validator.rs
@@ -492,8 +492,6 @@ where
         )?;
 
         let elapsed = validation_start.elapsed();
-        // `strategy` is a placeholder when SR is skipped; only surface it when SR actually ran.
-        let logged_strategy = calculate_state_root.then_some(strategy);
         info!(
             target: "flashblocks",
             execution_height,
@@ -501,7 +499,7 @@ where
             target_index,
             ?block_hash,
             full_sequence = calculate_state_root,
-            state_root_strategy = ?logged_strategy,
+            state_root_strategy = ?calculate_state_root.then_some(strategy),
             ?elapsed,
             "Executed and validated flashblocks sequence",
         );


### PR DESCRIPTION
## Summary

Adds the additional logging information for FB sequence validation duration, is full sequence flag (whether SR calculation happened) and SR strategy into the FB sequence validator.