### PR TITLE
feat(native AA): support EIP-8130 RPC methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -249,6 +249,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2304,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2862,7 +2863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -3691,13 +3692,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -4217,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -4829,7 +4829,7 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -5054,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5238,9 +5238,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -5251,6 +5251,7 @@ dependencies = [
  "serde_json",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -5325,9 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
  "bitflags",
  "libc",
@@ -5364,9 +5365,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -5795,10 +5796,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -5937,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 
 [[package]]
 name = "mach2"
@@ -6338,9 +6336,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -6952,7 +6950,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -7124,12 +7122,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plain_hasher"
@@ -7756,15 +7748,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -9994,6 +9977,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips 2.0.4",
  "alloy-json-rpc",
+ "alloy-op-evm",
  "alloy-primitives",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
@@ -11919,11 +11903,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -11938,9 +11923,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -12664,9 +12649,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -12830,9 +12815,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -12859,9 +12844,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -12890,9 +12875,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -13494,9 +13479,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -13507,9 +13492,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -13517,9 +13502,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -13527,9 +13512,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -13540,9 +13525,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -13610,9 +13595,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -14738,6 +14723,7 @@ dependencies = [
  "reth-optimism-forks",
  "reth-optimism-primitives",
  "reth-optimism-rpc",
+ "reth-optimism-txpool",
  "reth-primitives-traits",
  "reth-provider",
  "reth-revm",
@@ -14874,9 +14860,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -280,13 +280,15 @@ fn main() {
                     info!(target: "reth::cli", "xlayer AA accepted-verifiers RPC initialized");
 
                     // Register XLayerAA 2D-nonce override (eth_getTransactionCount).
-                    let tx_count_override =
-                        TransactionCountOverrideImpl::new(ctx.provider().clone());
-                    ctx.modules.add_or_replace_if_module_configured(
-                        RethRpcModule::Eth,
-                        TransactionCountOverrideServer::into_rpc(tx_count_override),
-                    )?;
-                    info!(target: "reth::cli", "xlayer AA 2D-nonce override (eth_getTransactionCount) initialized");
+                    if flashblocks_state.is_none() {
+                        let tx_count_override =
+                            TransactionCountOverrideImpl::new(ctx.registry.eth_api().clone());
+                        ctx.modules.add_or_replace_if_module_configured(
+                            RethRpcModule::Eth,
+                            TransactionCountOverrideServer::into_rpc(tx_count_override),
+                        )?;
+                        info!(target: "reth::cli", "xlayer AA 2D-nonce override (eth_getTransactionCount) initialized");
+                    }
 
                     // Register X Layer RPC
                     let peer_status = fb_p2p_status.get().cloned();

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -20,6 +20,7 @@ reth-chainspec.workspace = true
 reth-optimism-forks.workspace = true
 reth-optimism-rpc.workspace = true
 reth-optimism-primitives.workspace = true
+reth-optimism-txpool.workspace = true
 reth-primitives-traits.workspace = true
 reth-revm.workspace = true
 reth-rpc.workspace = true

--- a/crates/rpc/src/aa/mod.rs
+++ b/crates/rpc/src/aa/mod.rs
@@ -2,15 +2,14 @@
 //!
 //! Extends `eth_getTransactionCount` with an optional `nonce_key`
 //! parameter so callers can query the 2D nonce channel maintained by
-//! the `NonceManager` predeploy. Without this, AA clients have no
-//! cheap way to discover the next nonce for a `(sender, nonce_key)`
-//! pair.
+//! the `NonceManager` predeploy.
 //!
 //! AA receipt enrichment (`payer`, `phaseStatuses`) is handled directly
 //! inside the upstream `OpReceiptConverter` (see
 //! `op-reth/crates/rpc/src/eth/receipt.rs`) — no downstream wiring
 //! needed.
 
+pub mod pool;
 pub mod verifiers;
 
 use alloy_eips::BlockId;
@@ -20,8 +19,18 @@ use jsonrpsee::{
     proc_macros::rpc,
     types::{error::INTERNAL_ERROR_CODE, ErrorObjectOwned},
 };
+use op_alloy_network::Optimism;
 use op_revm::precompiles_xlayer::{aa_nonce_slot, NONCE_MANAGER_ADDRESS};
+use reth_optimism_rpc::{OpEthApi, OpEthApiError};
+use reth_optimism_txpool::Eip8130PoolView;
+use reth_rpc_eth_api::{
+    helpers::{FullEthApi, SpawnBlocking},
+    EthApiServer, EthApiTypes, RpcConvert, RpcNodeCore,
+};
+use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::StateProviderFactory;
+
+use crate::aa::pool::{layer_aa_pool_head, read_aa_slot};
 
 /// Reads the 2D nonce for `(address, nonce_key)` from the Nonce
 /// Manager predeploy's storage at the requested block.
@@ -52,18 +61,6 @@ pub fn read_2d_nonce<P: StateProviderFactory>(
 
 /// Overrides `eth_getTransactionCount` with an optional `nonce_key`
 /// parameter for 2D nonce channel queries.
-///
-/// **Naming.** We intentionally keep the method name
-/// `eth_getTransactionCount` (the exact standard one) rather than
-/// introducing a new namespace. Reth's JSON-RPC registry routes
-/// duplicate method names to the last-registered handler — so
-/// attaching this override after the stock eth module means a
-/// client calling `eth_getTransactionCount(addr, block)` continues
-/// to work unchanged, while a client that passes a third
-/// `nonce_key` argument transparently opts into the AA path.
-///
-/// Matches Base's surface: `nonce_key` is a camelCased U256 at
-/// position 2 (after address and block).
 #[rpc(server, namespace = "eth")]
 pub trait TransactionCountOverride {
     /// Returns the transaction count (nonce) for an address.
@@ -82,21 +79,29 @@ pub trait TransactionCountOverride {
 
 /// Server implementation of [`TransactionCountOverride`].
 #[derive(Debug, Clone)]
-pub struct TransactionCountOverrideImpl<Provider> {
-    provider: Provider,
+pub struct TransactionCountOverrideImpl<N: RpcNodeCore, Rpc: RpcConvert> {
+    eth_api: OpEthApi<N, Rpc>,
 }
 
-impl<Provider> TransactionCountOverrideImpl<Provider> {
-    /// Creates a new override wrapping the given state provider.
-    pub const fn new(provider: Provider) -> Self {
-        Self { provider }
+impl<N: RpcNodeCore, Rpc: RpcConvert> TransactionCountOverrideImpl<N, Rpc> {
+    pub const fn new(eth_api: OpEthApi<N, Rpc>) -> Self {
+        Self { eth_api }
     }
 }
 
 #[async_trait::async_trait]
-impl<Provider> TransactionCountOverrideServer for TransactionCountOverrideImpl<Provider>
+impl<N, Rpc> TransactionCountOverrideServer for TransactionCountOverrideImpl<N, Rpc>
 where
-    Provider: StateProviderFactory + Send + Sync + 'static,
+    N: RpcNodeCore,
+    Rpc: RpcConvert,
+    OpEthApi<N, Rpc>: FullEthApi<NetworkTypes = Optimism, Error = OpEthApiError>
+        + EthApiTypes<RpcConvert = Rpc>
+        + RpcNodeCore
+        + SpawnBlocking
+        + Send
+        + Sync
+        + 'static,
+    <OpEthApi<N, Rpc> as RpcNodeCore>::Pool: Eip8130PoolView,
 {
     async fn get_transaction_count(
         &self,
@@ -104,26 +109,28 @@ where
         block_number: Option<BlockId>,
         nonce_key: Option<U256>,
     ) -> RpcResult<U256> {
-        let block_id = block_number.unwrap_or_default();
         match nonce_key {
-            Some(key) => read_2d_nonce(&self.provider, address, block_id, key),
-            None => {
-                // Standard account-nonce path; delegates to the
-                // same state provider the stock eth module uses.
-                // Keeping this path here (rather than forwarding to
-                // the inner eth handler) means the override is
-                // self-contained and doesn't need an inner Arc of
-                // the eth module for the degenerate case.
-                let state = self
-                    .provider
-                    .state_by_block_id(block_id)
-                    .map_err(|e| rpc_internal_error(format!("state access error: {e}")))?;
-                let nonce = state
-                    .basic_account(&address)
-                    .map_err(|e| rpc_internal_error(format!("account read error: {e}")))?
-                    .map(|a| a.nonce)
-                    .unwrap_or_default();
-                Ok(U256::from(nonce))
+            // No `nonce_key` → defer to the upstream handler so the
+            // `pending` block tag still surfaces txpool-resident nonces
+            // (returns max(state nonce, highest_consecutive_pool_nonce + 1)).
+            None => EthApiServer::transaction_count(&self.eth_api, address, block_number).await,
+            // 2D nonce read against NonceManager predeploy storage. For the
+            // `pending` tag we additionally layer the AA pool's per-lane
+            // consecutive head, mirroring how the 1D path layers
+            // `get_highest_consecutive_transaction_by_sender`.
+            Some(key) => {
+                let block_id = block_number.unwrap_or_default();
+                self.eth_api
+                    .spawn_blocking_io_fut(move |this| async move {
+                        let state = this
+                            .provider()
+                            .state_by_block_id(block_id)
+                            .map_err(EthApiError::from)?;
+                        let slot_value = read_aa_slot(state.as_ref(), address, key)?;
+                        Ok(layer_aa_pool_head(this.pool(), address, key, slot_value, block_number))
+                    })
+                    .await
+                    .map_err(|e| -> jsonrpsee_types::error::ErrorObject<'static> { e.into() })
             }
         }
     }
@@ -162,8 +169,7 @@ mod tests {
         let slot = aa_nonce_slot(owner, nonce_key);
         provider.add_account(
             NONCE_MANAGER_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO)
-                .extend_storage([(slot.into(), U256::from(99u64))]),
+            ExtendedAccount::new(0, U256::ZERO).extend_storage([(slot.into(), U256::from(99u64))]),
         );
 
         let nonce = read_2d_nonce(&provider, owner, BlockId::default(), nonce_key).unwrap();
@@ -198,60 +204,5 @@ mod tests {
         let b = read_2d_nonce(&provider, owner, BlockId::default(), key_b).unwrap();
         assert_eq!(a, U256::from(11u64));
         assert_eq!(b, U256::from(22u64));
-    }
-
-    #[tokio::test]
-    async fn get_transaction_count_without_nonce_key_uses_account_nonce() {
-        let provider = MockEthProvider::default();
-        let address = Address::repeat_byte(0x22);
-        provider.add_account(address, ExtendedAccount::new(7, U256::ZERO));
-
-        let api = TransactionCountOverrideImpl::new(provider);
-        let nonce = TransactionCountOverrideServer::get_transaction_count(&api, address, None, None)
-            .await
-            .unwrap();
-        assert_eq!(nonce, U256::from(7u64));
-    }
-
-    #[tokio::test]
-    async fn get_transaction_count_unknown_address_returns_zero() {
-        let provider = MockEthProvider::default();
-        let api = TransactionCountOverrideImpl::new(provider);
-        let nonce = TransactionCountOverrideServer::get_transaction_count(
-            &api,
-            Address::repeat_byte(0x99),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-        assert_eq!(nonce, U256::ZERO);
-    }
-
-    #[tokio::test]
-    async fn get_transaction_count_with_nonce_key_uses_2d_nonce() {
-        let provider = MockEthProvider::default();
-        let address = Address::repeat_byte(0x33);
-        let nonce_key = U256::from(5u64);
-        let slot = aa_nonce_slot(address, nonce_key);
-        // Account-nonce field intentionally non-zero — the AA path must
-        // ignore it and read NonceManager storage instead.
-        provider.add_account(address, ExtendedAccount::new(1, U256::ZERO));
-        provider.add_account(
-            NONCE_MANAGER_ADDRESS,
-            ExtendedAccount::new(0, U256::ZERO)
-                .extend_storage([(slot.into(), U256::from(21u64))]),
-        );
-
-        let api = TransactionCountOverrideImpl::new(provider);
-        let nonce = TransactionCountOverrideServer::get_transaction_count(
-            &api,
-            address,
-            Some(BlockId::default()),
-            Some(nonce_key),
-        )
-        .await
-        .unwrap();
-        assert_eq!(nonce, U256::from(21u64));
     }
 }

--- a/crates/rpc/src/aa/pool.rs
+++ b/crates/rpc/src/aa/pool.rs
@@ -1,0 +1,46 @@
+//! Shared AA-pool / NonceManager helpers used by the `eth_getTransactionCount`
+//! overrides.
+
+use alloy_eips::BlockId;
+use alloy_primitives::{Address, U256};
+use op_revm::precompiles_xlayer::{aa_nonce_slot, NONCE_MANAGER_ADDRESS};
+use reth_optimism_txpool::{Eip8130PoolView, Eip8130SeqId};
+use reth_rpc_eth_types::EthApiError;
+use reth_storage_api::StateProvider;
+
+/// Reads `aa_nonce_slot(address, nonce_key)` from `NONCE_MANAGER_ADDRESS`.
+pub fn read_aa_slot<S: StateProvider + ?Sized>(
+    state: &S,
+    address: Address,
+    nonce_key: U256,
+) -> Result<U256, EthApiError> {
+    let slot = aa_nonce_slot(address, nonce_key);
+    Ok(state
+        .storage(NONCE_MANAGER_ADDRESS, slot.into())
+        .map_err(EthApiError::from)?
+        .unwrap_or_default())
+}
+
+/// Returns `max(slot_value, highest_consecutive_pool_seq + 1)` for
+/// `pending`, and the slot value unchanged for any other tag.
+pub fn layer_aa_pool_head<P>(
+    pool: &P,
+    address: Address,
+    nonce_key: U256,
+    slot_value: U256,
+    block_number: Option<BlockId>,
+) -> U256
+where
+    P: Eip8130PoolView,
+{
+    if block_number != Some(BlockId::pending()) {
+        return slot_value;
+    }
+    let baseline: u64 = slot_value.try_into().unwrap_or(u64::MAX);
+    let seq = Eip8130SeqId::new(address, nonce_key);
+    let Some(highest) = pool.highest_consecutive_aa_pending_seq_in_lane(seq, baseline) else {
+        return slot_value;
+    };
+    let next = highest.saturating_add(1);
+    slot_value.max(U256::from(next))
+}

--- a/crates/rpc/src/aa/verifiers.rs
+++ b/crates/rpc/src/aa/verifiers.rs
@@ -112,6 +112,13 @@ impl<Provider> AcceptedVerifiersImpl<Provider> {
 
 /// Builds the verifier-policy response for a given fork.
 pub fn build_response_for_spec(spec: OpSpecId) -> AcceptedVerifiersResponse {
+    if spec < OpSpecId::XLAYER_V1 {
+        return AcceptedVerifiersResponse {
+            accepts_unknown_verifiers: false,
+            verifiers: Vec::new(),
+        };
+    }
+
     let params = xlayer_gas_params(spec);
 
     // Worst-case Delegate budget = outer + most expensive native inner.
@@ -171,10 +178,8 @@ where
             .map_err(|e| rpc_internal_error(format!("latest header lookup failed: {e}")))?
             .map(|h| h.timestamp())
             .unwrap_or(0);
-        let spec = alloy_op_evm::spec_by_timestamp_after_bedrock(
-            &*self.provider.chain_spec(),
-            timestamp,
-        );
+        let spec =
+            alloy_op_evm::spec_by_timestamp_after_bedrock(&*self.provider.chain_spec(), timestamp);
         Ok(build_response_for_spec(spec))
     }
 }
@@ -231,16 +236,37 @@ mod tests {
         assert!(!json.contains("max_auth_cost"));
     }
 
-    /// Pre-XLAYER_V1 forks return zero `maxAuthCost` values: the gas
-    /// slots aren't populated yet, but the addresses are still
-    /// advertised so wallets can pre-build for the upcoming fork.
+    /// Pre-XLAYER_V1 forks return an empty verifier list with
+    /// `acceptsUnknownVerifiers: false` — the AA infrastructure isn't
+    /// active yet, and clients must not interpret the response as
+    /// "AA accepted today."
     #[test]
-    fn pre_xlayer_v1_returns_zero_gas_with_addresses_present() {
+    fn pre_xlayer_v1_returns_empty_response_with_acceptance_disabled() {
         let r = build_response_for_spec(OpSpecId::BEDROCK);
-        assert_eq!(r.verifiers.len(), 4);
-        for v in &r.verifiers {
-            assert!(v.native);
-            assert_eq!(v.max_auth_cost, U256::ZERO, "{:?} should have zero gas pre-XLAYER_V1", v.address);
+        assert!(!r.accepts_unknown_verifiers, "AA not active pre-XLAYER_V1");
+        assert!(r.verifiers.is_empty(), "no verifiers advertised before fork activation");
+    }
+
+    /// Boundary case: every fork from BEDROCK up to (but not including)
+    /// XLAYER_V1 must produce the empty response. Catches regressions
+    /// where a new intermediate fork is introduced and the gating cutoff
+    /// silently shifts.
+    #[test]
+    fn forks_strictly_before_xlayer_v1_are_all_gated() {
+        for spec in [
+            OpSpecId::BEDROCK,
+            OpSpecId::REGOLITH,
+            OpSpecId::CANYON,
+            OpSpecId::ECOTONE,
+            OpSpecId::FJORD,
+            OpSpecId::GRANITE,
+            OpSpecId::HOLOCENE,
+            OpSpecId::ISTHMUS,
+            OpSpecId::JOVIAN,
+        ] {
+            let r = build_response_for_spec(spec);
+            assert!(!r.accepts_unknown_verifiers, "{spec:?}: must not accept AA pre-XLAYER_V1");
+            assert!(r.verifiers.is_empty(), "{spec:?}: must not advertise verifiers pre-XLAYER_V1");
         }
     }
 }

--- a/crates/rpc/src/eth.rs
+++ b/crates/rpc/src/eth.rs
@@ -24,6 +24,7 @@ use op_alloy_rpc_types::OpTransactionRequest;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_rpc::{OpEthApi, OpEthApiError};
+use reth_optimism_txpool::Eip8130PoolView;
 use reth_primitives_traits::SealedHeaderFor;
 use reth_revm::{database::StateProviderDatabase, db::State};
 use reth_rpc_convert::{RpcConvert, RpcTransaction};
@@ -35,10 +36,12 @@ use reth_rpc_eth_types::{
     block::convert_transaction_receipt, EthApiError, RpcInvalidTransactionError,
 };
 use reth_rpc_server_types::result::ToRpcResult;
-use reth_storage_api::{StateProvider, StateProviderBox, StateProviderFactory};
+use reth_storage_api::{StateProviderBox, StateProviderFactory};
 use reth_transaction_pool::TransactionPool;
 
 use xlayer_flashblocks::FlashblockStateCache;
+
+use crate::aa::pool::{layer_aa_pool_head, read_aa_slot};
 
 /// Eth API override for flashblocks RPC integration.
 #[cfg_attr(not(test), rpc(server, namespace = "eth"))]
@@ -190,11 +193,17 @@ pub trait FlashblocksEthApiOverride {
 
     /// Returns the number of transactions sent from an address at given block number, with the
     /// flashblock state cache overlay support for pending and confirmed block states.
+    ///
+    /// When `nonce_key` is provided, returns the EIP-8130 2D-nonce for that lane
+    /// (`(address, nonce_key)`) by reading `aa_nonce_slot` on `NONCE_MANAGER_ADDRESS`
+    /// against the same flashblock overlay used for the 1D path, so post-flashblock
+    /// AA-tx slot bumps are reflected before the block is canonicalized.
     #[method(name = "getTransactionCount")]
     async fn transaction_count(
         &self,
         address: Address,
         block_number: Option<BlockId>,
+        nonce_key: Option<U256>,
     ) -> RpcResult<U256>;
 
     /// Returns code at a given address at given block number, with the flashblock state cache
@@ -250,6 +259,7 @@ where
         + Send
         + Sync
         + 'static,
+    <OpEthApi<N, Rpc> as RpcNodeCore>::Pool: Eip8130PoolView,
 {
     // ----------------- Block apis -----------------
     /// Handler for: `eth_blockNumber`
@@ -580,8 +590,47 @@ where
         &self,
         address: Address,
         block_number: Option<BlockId>,
+        nonce_key: Option<U256>,
     ) -> RpcResult<U256> {
-        trace!(target: "rpc::eth", ?address, ?block_number, "Serving eth_getTransactionCount");
+        trace!(target: "rpc::eth", ?address, ?block_number, ?nonce_key, "Serving eth_getTransactionCount");
+
+        // EIP-8130 2D-nonce path. Reads `aa_nonce_slot(address, key)` on the
+        // NonceManager predeploy. The flashblock overlay layers in-memory
+        // bundle-state storage writes on top of canonical state.
+        //
+        // For the `pending` tag we additionally layer the AA pool's per-lane
+        // consecutive head, analogous to how the 1D path layers
+        // `get_highest_consecutive_transaction_by_sender`. This closes the
+        // window where an AA tx has been admitted to the pool but not yet
+        // included in any subblock — without it, a wallet polling for its
+        // next sequence inside that ~200ms window would get a stale answer.
+        if let Some(key) = nonce_key {
+            if let Some((state, _)) = self.get_flashblock_state_provider_by_id(block_number)? {
+                return self
+                    .eth_api
+                    .spawn_blocking_io_fut(move |this| async move {
+                        let slot_value = read_aa_slot(state.as_ref(), address, key)?;
+                        Ok(layer_aa_pool_head(this.pool(), address, key, slot_value, block_number))
+                    })
+                    .await
+                    .map_err(|e| -> jsonrpsee_types::error::ErrorObject<'static> { e.into() });
+            }
+            // No overlay for this block id → read against canonical state.
+            // Mirrors `TransactionCountOverrideImpl` so behavior is identical
+            // when the flashblocks cache is empty / disabled at this height.
+            let block_id = block_number.unwrap_or_default();
+            return self
+                .eth_api
+                .spawn_blocking_io_fut(move |this| async move {
+                    let state =
+                        this.provider().state_by_block_id(block_id).map_err(EthApiError::from)?;
+                    let slot_value = read_aa_slot(state.as_ref(), address, key)?;
+                    Ok(layer_aa_pool_head(this.pool(), address, key, slot_value, block_number))
+                })
+                .await
+                .map_err(|e| -> jsonrpsee_types::error::ErrorObject<'static> { e.into() });
+        }
+
         if let Some((state, _)) = self.get_flashblock_state_provider_by_id(block_number)? {
             return self
                 .eth_api


### PR DESCRIPTION
## Summary
Supports and extends RPC methods for EIP-8130 transactions.
1. `eth_getTransactionCount` - Extend with optional `nonceKey` parameter (uint256) to query 2D nonce channels. Reads from the Nonce Manager precompile at `NONCE_MANAGER_ADDRESS`.
2. `eth_getTransactionReceipt` - https://github.com/okx/optimism/pull/238
3. `eth_getAcceptedVerifiers` - Returns the node's verifier acceptance policy

EIP-8130 spec for reference: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8130.md#rpc-extensions

## Details
### `eth_getTransactionCount` 
- On flashblocks-enabled nodes, layers the AA pool's pending entries on top of the flashblock overlay so AA transactions that haven't yet been executed in any subblock still surface in the response.
- Sample request (query nonce sequence of nonce key `0x1`): 
```
{"jsonrpc":"2.0",
"method":"eth_getTransactionCount",
"params":["0x5a25CD582994e848207bdcF0c5e050a6Cd8Bf36A","latest","0x1"],
"id":1}
```

- Sample response :
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0x1" # nonce sequence of nonce key 1 
}
```

### `eth_getTransactionReceipt`
- Refer to  https://github.com/okx/optimism/pull/238

### `eth_getAcceptedVerifiers`
- Returns a list of signature verification algorithms (P256, k1, WebAuthn, etc..) that the node accepts and can validate for AA transactions.
- `acceptsUnknownVerifiers` - Whether the node will accept a verifier address that is not in the explicit verifiers allowlist.
    - Currently hardcoded to `true` - When the AA handler hits a verifier address that isn't in the list, it doesn't reject. It falls back to `STATICCALL`-ing that address as a regular EVM contract, capped by                   `XLAYER_AA_CUSTOM_VERIFIER_GAS_CAP` which prevents DoS via expensive verifier contracts.
    - When a future change adds a declarative allowlist mechanism — e.g. a CLI flag like --strict-verifier-allowlist or a chainspec entry listing accepted verifiers — node operators could opt into strict mode which will allow the toggle between `true` and `false`.
- `address` - On-chain address of the verifier contract
- `native` - Whether node has built-in, optimized code for this algorithm (e.g. K1 (ecrecover))
- `maxAuthCost` - Maximum gas the node will allow for signature verification with this verifier
- Sample request:
```
{"jsonrpc":"2.0","method":"eth_getAcceptedVerifiers","params":[],"id":1}
```
- Sample response:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "acceptsUnknownVerifiers": true,
        "verifiers": [
            {
                "address": "0x0000000000000000000000000000000000000001",
                "native": true,
                "maxAuthCost": "0x1770"
            },
            {
                "address": "0x75e9779603e826f2d8d4dd7edee3f0a737e4228d",
                "native": true,
                "maxAuthCost": "0x251c"
            },
            {
                "address": "0xb2c8b7ec119882fbcc32fde1be1341e19a5bd53e",
                "native": true,
                "maxAuthCost": "0x3a98"
            },
            {
                "address": "0x30a76831b27732087561372f6a1bef6fc391d805",
                "native": true,
                "maxAuthCost": "0x5208"
            }
        ]
    }
}
```

## Unit Tests
Command to run unit tests:
```
cargo test -p xlayer-rpc --lib aa
```